### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/src/Torrentarr.WebUI/Program.cs
+++ b/src/Torrentarr.WebUI/Program.cs
@@ -634,13 +634,26 @@ app.MapGet("/web/logs/{name}/download", (string name, HttpResponse response) =>
 {
     // Sanitize: only allow the filename component (no directory traversal)
     var safeName = Path.GetFileName(name);
-    var logFile = Path.Combine(logsPath, safeName);
+    if (string.IsNullOrWhiteSpace(safeName))
+    {
+        return Results.BadRequest(new { error = "Invalid log file name" });
+    }
 
-    if (!File.Exists(logFile))
+    // Resolve the full paths and ensure the requested file stays within the logs directory
+    var fullLogsPath = Path.GetFullPath(logsPath);
+    var combinedPath = Path.Combine(fullLogsPath, safeName);
+    var fullLogFile = Path.GetFullPath(combinedPath);
+
+    if (!fullLogFile.StartsWith(fullLogsPath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+    {
+        return Results.BadRequest(new { error = "Invalid log file name" });
+    }
+
+    if (!File.Exists(fullLogFile))
         return Results.NotFound(new { error = "Log file not found" });
 
     response.Headers["Content-Disposition"] = $"attachment; filename=\"{safeName}\"";
-    return Results.File(logFile, "application/octet-stream", safeName);
+    return Results.File(fullLogFile, "application/octet-stream", safeName);
 });
 
 // Radarr movies for specific category


### PR DESCRIPTION
Potential fix for [https://github.com/Feramance/Torrentarr/security/code-scanning/3](https://github.com/Feramance/Torrentarr/security/code-scanning/3)

In general, to fix uncontrolled path usage you should (1) constrain user input to an expected pattern (e.g., only simple filenames with a particular extension), and (2) ensure that the resolved path is still within an intended base directory after normalization. This eliminates directory traversal and prevents access to unexpected files.

For this specific route in `src/Torrentarr.WebUI/Program.cs`, the best targeted fix without changing behavior is:

1. Continue to reduce `name` to a simple filename using `Path.GetFileName`.
2. Reject any filename that is empty, contains suspicious sequences, or does not match the expected log file pattern (for example, require a “.log” suffix, or at least prevent path separators and `..`—even though `GetFileName` already strips them, an explicit check makes intent and safety clear to both humans and tools).
3. Compute the combined path, normalize it with `Path.GetFullPath`, and ensure that it starts with the normalized `logsPath` (plus a directory separator) to assert it is inside the logs directory.
4. Use this verified `logFile` for the subsequent `File.Exists` check and `Results.File` call.

Concretely, within the existing handler for `/web/logs/{name}/download` (around lines 633–644 in `Program.cs`), replace the current computation of `safeName`/`logFile` with a slightly expanded block that:

- Gets `safeName = Path.GetFileName(name)`.
- Validates `safeName` is not null/empty and lacks invalid characters or patterns; at minimum, reject if it is empty after `GetFileName`.
- Builds `logFileCandidate = Path.Combine(logsPath, safeName)` and `fullLogFile = Path.GetFullPath(logFileCandidate)`.
- Builds `fullLogsPath = Path.GetFullPath(logsPath)` and checks `fullLogFile.StartsWith(fullLogsPath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)` (and equality for the directory itself if you consider that case).
- If the check fails, return `Results.BadRequest(new { error = "Invalid log file name" })`.

No new helper methods or external libraries are required; we can use `System.IO.Path` and `System.IO.File`, which are already in use implicitly. The rest of the handler logic (setting `Content-Disposition` and returning `Results.File`) can remain the same, but should use `fullLogFile` instead of the unverified `logFile`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
