### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/src/Torrentarr.WebUI/Program.cs
+++ b/src/Torrentarr.WebUI/Program.cs
@@ -610,7 +610,24 @@ app.MapGet("/web/logs", () =>
 // Log file contents
 app.MapGet("/web/logs/{name}", async (string name, int? lines) =>
 {
-    var logFile = Path.Combine(logsPath, name);
+    // Sanitize: only allow the filename component (no directory traversal)
+    var safeName = Path.GetFileName(name);
+
+    // Optional: enforce .log extension to align with listed log files
+    if (!safeName.EndsWith(".log", StringComparison.OrdinalIgnoreCase) || string.IsNullOrWhiteSpace(safeName))
+    {
+        return Results.BadRequest(new { error = "Invalid log file name" });
+    }
+
+    var basePath = Path.GetFullPath(logsPath);
+    var logFile = Path.GetFullPath(Path.Combine(basePath, safeName));
+
+    // Ensure the resolved path stays within the logs directory
+    if (!logFile.StartsWith(basePath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+        && !string.Equals(logFile, basePath, StringComparison.OrdinalIgnoreCase))
+    {
+        return Results.BadRequest(new { error = "Invalid log file path" });
+    }
 
     if (!File.Exists(logFile))
     {
@@ -623,7 +640,7 @@ app.MapGet("/web/logs/{name}", async (string name, int? lines) =>
 
     return Results.Ok(new
     {
-        name,
+        name = safeName,
         lines = logLines,
         totalLines = content.Split('\n').Length
     });


### PR DESCRIPTION
Potential fix for [https://github.com/Feramance/Torrentarr/security/code-scanning/2](https://github.com/Feramance/Torrentarr/security/code-scanning/2)

In general, fix this by constraining the user-controlled `name` to a safe file name and ensuring the resulting path remains inside the expected `logsPath` directory. Commonly this means: (1) reducing the input to its file-name component with `Path.GetFileName`, which strips directory traversal sequences; (2) optionally enforcing an extension or allow list; and (3) checking that the fully resolved path starts with the intended base directory.

For this specific code, the least intrusive fix that preserves existing functionality is to do the following in the `/web/logs/{name}` handler:

1. Derive a `safeName` using `Path.GetFileName(name)` so that `name` cannot include directory separators.
2. Combine `logsPath` and `safeName` to form `logFile`.
3. Optionally, ensure `safeName` ends with `.log` to match the files listed by `/web/logs`.
4. Optionally, normalize both `logsPath` and `logFile` with `Path.GetFullPath` and verify that `logFile` starts with `logsPath` plus a directory separator, to prevent edge cases where `logsPath` could be a prefix of another directory.
5. Keep using `File.Exists` and `File.ReadAllTextAsync` on the validated `logFile`.

We should mirror the approach already used in the `/web/logs/{name}/download` endpoint (lines 633–643), so behavior stays consistent across endpoints. No new methods or imports are required; all needed APIs (`Path`, `File`) are already in use. All changes are confined to `src/Torrentarr.WebUI/Program.cs` in the `/web/logs/{name}` handler body.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
