### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/src/Torrentarr.WebUI/Program.cs
+++ b/src/Torrentarr.WebUI/Program.cs
@@ -610,15 +610,33 @@ app.MapGet("/web/logs", () =>
 // Log file contents
 app.MapGet("/web/logs/{name}", async (string name, int? lines) =>
 {
-    var logFile = Path.Combine(logsPath, name);
+    // Validate that the provided name does not contain directory traversal or separators
+    if (string.IsNullOrWhiteSpace(name) ||
+        name.Contains("..", StringComparison.Ordinal) ||
+        name.Contains(Path.DirectorySeparatorChar) ||
+        name.Contains(Path.AltDirectorySeparatorChar))
+    {
+        return Results.BadRequest(new { error = "Invalid log file name" });
+    }
 
-    if (!File.Exists(logFile))
+    var logFile = Path.Combine(logsPath, name);
+    var logsPathFull = Path.GetFullPath(logsPath);
+    var logFileFull = Path.GetFullPath(logFile);
+
+    // Ensure the resolved path stays within the logs directory
+    if (!logFileFull.StartsWith(logsPathFull + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+        !string.Equals(logFileFull, logsPathFull, StringComparison.Ordinal))
+    {
+        return Results.BadRequest(new { error = "Invalid log file path" });
+    }
+
+    if (!File.Exists(logFileFull))
     {
         return Results.NotFound(new { error = "Log file not found" });
     }
 
     var lineCount = lines ?? 100;
-    var content = await File.ReadAllTextAsync(logFile);
+    var content = await File.ReadAllTextAsync(logFileFull);
     var logLines = content.Split('\n').TakeLast(lineCount).ToList();
 
     return Results.Ok(new


### PR DESCRIPTION
Potential fix for [https://github.com/Feramance/Torrentarr/security/code-scanning/1](https://github.com/Feramance/Torrentarr/security/code-scanning/1)

In general, to fix this class of issue you must ensure that any user-controlled path component is either (a) constrained to a safe, single path segment with no separators or `..`, or (b) combined with a trusted base directory and then verified so the final canonical path still resides within that base directory. For a log viewer endpoint, the correct behavior is normally to restrict access strictly to files in the designated logs directory.

The best fix here without changing functionality is: keep using `logsPath` as the base, but add validation for `name` and an additional check after combining the paths. Concretely:
- Immediately reject any `name` that is null/empty or contains directory separators (`/` or `\`) or `..` (parent directory references).
- Build `logFile` and `logsPathFull` using `Path.GetFullPath` to canonicalize them.
- Ensure `logFileFull` starts with `logsPathFull` plus a directory separator (or exactly equals `logsPathFull` if directories are possible), and reject the request if it does not. This protects against tricks with `.`/`..` or symlinks relative to the base path.
- Optionally normalize `name` to `Path.GetFileName(name)` before combining, but the explicit checks above are enough.

These changes all belong in `src/Torrentarr.WebUI/Program.cs` inside the `/web/logs/{name}` endpoint, around lines 611–621. No new external dependencies are required; all needed APIs are in `System.IO` and `System`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
