### PR TITLE
fix: consolidate critical correctness and security fixes

### DIFF
--- a/src/Torrentarr.Core/Configuration/ConfigurationLoader.cs
+++ b/src/Torrentarr.Core/Configuration/ConfigurationLoader.cs
@@ -1779,7 +1779,7 @@ public class ConfigurationLoader
                 sb.AppendLine("#          URI = \"tracker.example.com\"");
                 sb.AppendLine("#          Priority = 1");
             }
-            sb.AppendLine("Trackers = []");
+            AppendTrackersSection(sb, name, qbit.Trackers);
             sb.AppendLine();
 
             sb.AppendLine($"[{name}.CategorySeeding]");
@@ -1845,34 +1845,7 @@ public class ConfigurationLoader
             // HnR settings are now tracker-only (removed from SeedingMode in v5.9.1)
             sb.AppendLine();
 
-            // [[Arr.Torrent.Trackers]] array-of-tables
-            foreach (var tracker in instance.Torrent.Trackers)
-            {
-                sb.AppendLine($"[[{kvp.Key}.Torrent.Trackers]]");
-                if (!string.IsNullOrEmpty(tracker.Name))
-                    sb.AppendLine($"Name = \"{EscapeTomlString(tracker.Name)}\"");
-                sb.AppendLine($"URI = \"{tracker.Uri}\"");
-                sb.AppendLine($"Priority = {tracker.Priority}");
-                sb.AppendLine($"SortTorrents = {tracker.SortTorrents.ToString().ToLower()}");
-                sb.AppendLine($"MaximumETA = {tracker.MaxETA ?? -1}");
-                sb.AppendLine($"DownloadRateLimit = {tracker.DownloadRateLimit ?? -1}");
-                sb.AppendLine($"UploadRateLimit = {tracker.UploadRateLimit ?? -1}");
-                sb.AppendLine($"MaxUploadRatio = {tracker.MaxUploadRatio ?? -1}");
-                sb.AppendLine($"MaxSeedingTime = {tracker.MaxSeedingTime ?? -1}");
-                sb.AppendLine($"HitAndRunMode = \"{tracker.HitAndRunMode ?? "disabled"}\"");
-                sb.AppendLine($"MinSeedRatio = {tracker.MinSeedRatio ?? 1.0}");
-                sb.AppendLine($"MinSeedingTime = {tracker.MinSeedingTimeDays ?? 0}"); // TOML key is MinSeedingTime (qBitrr compat)
-                sb.AppendLine($"HitAndRunPartialSeedRatio = {tracker.HitAndRunPartialSeedRatio ?? 1.0}");
-                sb.AppendLine($"TrackerUpdateBuffer = {tracker.TrackerUpdateBuffer ?? 0}");
-                sb.AppendLine($"HitAndRunMinimumDownloadPercent = {tracker.HitAndRunMinimumDownloadPercent ?? 10}");
-                if (tracker.SuperSeedMode.HasValue)
-                    sb.AppendLine($"SuperSeedMode = {tracker.SuperSeedMode.Value.ToString().ToLower()}");
-                sb.AppendLine($"RemoveIfExists = {tracker.RemoveIfExists.ToString().ToLower()}");
-                sb.AppendLine($"AddTrackerIfMissing = {tracker.AddTrackerIfMissing.ToString().ToLower()}");
-                if (tracker.AddTags.Count > 0)
-                    sb.AppendLine($"AddTags = [{string.Join(", ", tracker.AddTags.Select(t => $"'{t}'"))}]");
-                sb.AppendLine();
-            }
+            AppendTrackersSection(sb, $"{kvp.Key}.Torrent", instance.Torrent.Trackers);
 
             // EntrySearch section
             sb.AppendLine($"[{kvp.Key}.EntrySearch]");
@@ -1934,6 +1907,43 @@ public class ConfigurationLoader
         }
 
         return sb.ToString();
+    }
+
+    private static void AppendTrackersSection(System.Text.StringBuilder sb, string sectionPath, List<TrackerConfig> trackers)
+    {
+        if (trackers.Count == 0)
+        {
+            sb.AppendLine("Trackers = []");
+            return;
+        }
+
+        foreach (var tracker in trackers)
+        {
+            sb.AppendLine($"[[{sectionPath}.Trackers]]");
+            if (!string.IsNullOrEmpty(tracker.Name))
+                sb.AppendLine($"Name = \"{EscapeTomlString(tracker.Name)}\"");
+            sb.AppendLine($"URI = \"{tracker.Uri}\"");
+            sb.AppendLine($"Priority = {tracker.Priority}");
+            sb.AppendLine($"SortTorrents = {tracker.SortTorrents.ToString().ToLower()}");
+            sb.AppendLine($"MaximumETA = {tracker.MaxETA ?? -1}");
+            sb.AppendLine($"DownloadRateLimit = {tracker.DownloadRateLimit ?? -1}");
+            sb.AppendLine($"UploadRateLimit = {tracker.UploadRateLimit ?? -1}");
+            sb.AppendLine($"MaxUploadRatio = {tracker.MaxUploadRatio ?? -1}");
+            sb.AppendLine($"MaxSeedingTime = {tracker.MaxSeedingTime ?? -1}");
+            sb.AppendLine($"HitAndRunMode = \"{tracker.HitAndRunMode ?? "disabled"}\"");
+            sb.AppendLine($"MinSeedRatio = {tracker.MinSeedRatio ?? 1.0}");
+            sb.AppendLine($"MinSeedingTime = {tracker.MinSeedingTimeDays ?? 0}"); // TOML key is MinSeedingTime (qBitrr compat)
+            sb.AppendLine($"HitAndRunPartialSeedRatio = {tracker.HitAndRunPartialSeedRatio ?? 1.0}");
+            sb.AppendLine($"TrackerUpdateBuffer = {tracker.TrackerUpdateBuffer ?? 0}");
+            sb.AppendLine($"HitAndRunMinimumDownloadPercent = {tracker.HitAndRunMinimumDownloadPercent ?? 10}");
+            if (tracker.SuperSeedMode.HasValue)
+                sb.AppendLine($"SuperSeedMode = {tracker.SuperSeedMode.Value.ToString().ToLower()}");
+            sb.AppendLine($"RemoveIfExists = {tracker.RemoveIfExists.ToString().ToLower()}");
+            sb.AppendLine($"AddTrackerIfMissing = {tracker.AddTrackerIfMissing.ToString().ToLower()}");
+            if (tracker.AddTags.Count > 0)
+                sb.AppendLine($"AddTags = [{string.Join(", ", tracker.AddTags.Select(t => $"'{t}'"))}]");
+            sb.AppendLine();
+        }
     }
 
     /// <summary>

--- a/src/Torrentarr.Core/Configuration/TorrentPolicyHelper.cs
+++ b/src/Torrentarr.Core/Configuration/TorrentPolicyHelper.cs
@@ -102,14 +102,25 @@ public static class TorrentPolicyHelper
     }
 
     /// <summary>
-    /// Active download states for free-space evaluation (includes <c>metaDL</c>).
+    /// Active download states for free-space evaluation (qBitrr <c>is_free_space_download_state</c> active subset).
     /// </summary>
     public static bool IsActiveDownloadingStateForFreeSpace(string? state)
     {
         if (string.IsNullOrWhiteSpace(state)) return false;
         return state.Contains("downloading", StringComparison.OrdinalIgnoreCase)
                || state.Contains("stalledDL", StringComparison.OrdinalIgnoreCase)
+               || state.Contains("queuedDL", StringComparison.OrdinalIgnoreCase)
+               || state.Contains("forcedDL", StringComparison.OrdinalIgnoreCase)
                || state.Contains("metaDL", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Download-side states considered by free-space pause/resume (qBitrr <c>is_free_space_download_state</c>).
+    /// </summary>
+    public static bool IsFreeSpaceDownloadState(string? state)
+    {
+        return IsActiveDownloadingStateForFreeSpace(state)
+               || IsPausedDownloadStateForFreeSpace(state);
     }
 
     /// <summary>

--- a/src/Torrentarr.Core/Configuration/TorrentPolicyHelper.cs
+++ b/src/Torrentarr.Core/Configuration/TorrentPolicyHelper.cs
@@ -102,6 +102,27 @@ public static class TorrentPolicyHelper
     }
 
     /// <summary>
+    /// Active download states for free-space evaluation (includes <c>metaDL</c>).
+    /// </summary>
+    public static bool IsActiveDownloadingStateForFreeSpace(string? state)
+    {
+        if (string.IsNullOrWhiteSpace(state)) return false;
+        return state.Contains("downloading", StringComparison.OrdinalIgnoreCase)
+               || state.Contains("stalledDL", StringComparison.OrdinalIgnoreCase)
+               || state.Contains("metaDL", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Paused download states for free-space resume/pause (qBittorrent v5+ uses <c>stoppedDL</c>).
+    /// </summary>
+    public static bool IsPausedDownloadStateForFreeSpace(string? state)
+    {
+        if (string.IsNullOrWhiteSpace(state)) return false;
+        return state.Contains("pausedDL", StringComparison.OrdinalIgnoreCase)
+               || state.Contains("stoppedDL", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Seeding / upload side of qBittorrent queue for <c>SortTorrents</c> (arss.py <c>is_queue_seeding_for_sort</c>).
     /// Includes <c>stoppedUP</c> (qBittorrent v5+; replaces <c>pausedUP</c> in the API).
     /// </summary>

--- a/src/Torrentarr.Core/Configuration/UrlBaseHelper.cs
+++ b/src/Torrentarr.Core/Configuration/UrlBaseHelper.cs
@@ -14,4 +14,15 @@ public static class UrlBaseHelper
             raw = "/" + raw;
         return raw.TrimEnd('/');
     }
+
+    /// <summary>Prefix <paramref name="path"/> with a path base (configured UrlBase or request PathBase).</summary>
+    public static string WithUrlBase(string urlBase, string path)
+    {
+        urlBase ??= "";
+        if (string.IsNullOrEmpty(path))
+            return urlBase;
+        if (!path.StartsWith('/'))
+            path = "/" + path;
+        return string.IsNullOrEmpty(urlBase) ? path : urlBase + path;
+    }
 }

--- a/src/Torrentarr.Core/Torrentarr.Core.csproj
+++ b/src/Torrentarr.Core/Torrentarr.Core.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Torrentarr.Host/Program.cs
+++ b/src/Torrentarr.Host/Program.cs
@@ -2968,7 +2968,7 @@ class ProcessOrchestratorService : BackgroundService
         if (tagless && dbContext != null)
         {
             var dbEntry = await dbContext.TorrentLibrary.AsNoTracking()
-                .FirstOrDefaultAsync(t => t.Hash == torrent.Hash, cancellationToken);
+                .FirstOrDefaultAsync(t => t.Hash == torrent.Hash && t.QbitInstance == instanceName, cancellationToken);
             hasFreeSpaceTag = dbEntry?.FreeSpacePaused == true;
         }
         else

--- a/src/Torrentarr.Host/Program.cs
+++ b/src/Torrentarr.Host/Program.cs
@@ -3143,7 +3143,7 @@ class ProcessOrchestratorService : BackgroundService
 
                 foreach (var t in torrents)
                 {
-                    if (t.Tags.Contains("qBitrr-ignored", StringComparison.OrdinalIgnoreCase))
+                    if (t.Tags?.Contains("qBitrr-ignored", StringComparison.OrdinalIgnoreCase) == true)
                         continue;
                     t.QBitInstanceName = instanceName;
                     await seeding.ApplyTrackerActionsForTorrentAsync(t, cancellationToken);
@@ -3330,9 +3330,8 @@ class ProcessOrchestratorService : BackgroundService
         const string freeSpacePausedTag = "qBitrr-free_space_paused";
         var tagless = _config.Settings.Tagless;
 
-        var isDownloading = torrent.State.Contains("downloading", StringComparison.OrdinalIgnoreCase) ||
-                           torrent.State.Contains("stalledDL", StringComparison.OrdinalIgnoreCase);
-        var isPausedDownload = torrent.State.Contains("pausedDL", StringComparison.OrdinalIgnoreCase);
+        var isDownloading = TorrentPolicyHelper.IsActiveDownloadingStateForFreeSpace(torrent.State);
+        var isPausedDownload = TorrentPolicyHelper.IsPausedDownloadStateForFreeSpace(torrent.State);
 
         // §1.6: tagless mode reads FreeSpacePaused from DB column; otherwise check qBit tag
         bool hasFreeSpaceTag;

--- a/src/Torrentarr.Host/Program.cs
+++ b/src/Torrentarr.Host/Program.cs
@@ -1246,120 +1246,14 @@ try
             if (!payload.TryGetProperty("changes", out var changesEl))
                 return Results.BadRequest(new { error = "Missing 'changes' field" });
 
-            var newtonsoftSettings = new Newtonsoft.Json.JsonSerializerSettings
-            {
-                ContractResolver = new Newtonsoft.Json.Serialization.DefaultContractResolver(),
-                NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
-                // Replace collections on deserialization to avoid appending to constructor-initialized defaults
-                ObjectCreationHandling = Newtonsoft.Json.ObjectCreationHandling.Replace,
-            };
-            var serializer = Newtonsoft.Json.JsonSerializer.Create(newtonsoftSettings);
-
-            // Step 1: Snapshot current config as a flat-section JObject (mirrors GET /web/config).
-            // Keys are section names ("Settings", "WebUI", "qBit", "Radarr-1080", …).
-            var currentObj = new Newtonsoft.Json.Linq.JObject();
-            currentObj["Settings"] = Newtonsoft.Json.Linq.JObject.FromObject(cfg.Settings, serializer);
-            currentObj["WebUI"] = Newtonsoft.Json.Linq.JObject.FromObject(cfg.WebUI, serializer);
-            foreach (var (key, qbit) in cfg.QBitInstances.Where(kv => kv.Value.Host != "CHANGE_ME"))
-                currentObj[key] = Newtonsoft.Json.Linq.JObject.FromObject(qbit, serializer);
-            foreach (var (key, arr) in cfg.ArrInstances)
-                currentObj[key] = Newtonsoft.Json.Linq.JObject.FromObject(arr, serializer);
-
-            // Step 2: Apply each dotted-key change onto the snapshot.
-            // e.g. "Settings.ConsoleLevel" → sets currentObj["Settings"]["ConsoleLevel"].
-            // null value means delete.
             var changesObj = Newtonsoft.Json.Linq.JObject.Parse(changesEl.GetRawText());
-            foreach (var change in changesObj.Properties())
-            {
-                // Reject protected keys (qBitrr parity)
-                if (string.Equals(change.Name, "Settings.ConfigVersion", StringComparison.OrdinalIgnoreCase))
-                    return Results.Json(new { error = "Cannot modify protected configuration key: Settings.ConfigVersion" }, statusCode: 403);
+            var (updatedConfig, applyError) = ApplyDottedConfigChanges(cfg, changesObj);
+            if (applyError != null)
+                return applyError;
+            if (updatedConfig == null)
+                return Results.BadRequest(new { error = "Invalid config payload" });
 
-                // Never overwrite a real secret with the redaction placeholder from the frontend
-                if (IsSensitiveDottedKey(change.Name) &&
-                    change.Value.Type == Newtonsoft.Json.Linq.JTokenType.String &&
-                    change.Value.ToString() == REDACTED_PLACEHOLDER)
-                    continue;
-
-                var parts = change.Name.Split('.');
-                var rawSectionKey = parts[0];
-                // Case-insensitive section key: "webui" → "WebUI", "settings" → "Settings"
-                var sectionKey = currentObj.Properties()
-                    .FirstOrDefault(p => p.Name.Equals(rawSectionKey, StringComparison.OrdinalIgnoreCase))?.Name
-                    ?? rawSectionKey;
-                if (change.Value.Type == Newtonsoft.Json.Linq.JTokenType.Null)
-                {
-                    // Deletion
-                    if (parts.Length == 1)
-                        currentObj.Remove(sectionKey);
-                    else if (currentObj[sectionKey] is Newtonsoft.Json.Linq.JObject sect)
-                        DeleteNestedToken(sect, parts, 1);
-                }
-                else if (parts.Length == 1)
-                {
-                    currentObj[sectionKey] = change.Value;
-                }
-                else
-                {
-                    if (currentObj[sectionKey] is not Newtonsoft.Json.Linq.JObject sect)
-                    {
-                        sect = new Newtonsoft.Json.Linq.JObject();
-                        currentObj[sectionKey] = sect;
-                    }
-                    SetNestedToken(sect, parts, 1, change.Value);
-                }
-            }
-
-            // Cleanup: remove sections that had all their keys deleted (became empty {}).
-            // This handles renames: the old section has all sub-keys set to null → empty JObject.
-            foreach (var emptyProp in currentObj.Properties().ToList())
-            {
-                if (emptyProp.Value is Newtonsoft.Json.Linq.JObject emptyObj && !emptyObj.Properties().Any())
-                    currentObj.Remove(emptyProp.Name);
-            }
-
-            // Step 3: Reconstruct TorrentarrConfig from the updated flat-section JObject.
-            var updatedConfig = new TorrentarrConfig();
-            if (currentObj["Settings"] is Newtonsoft.Json.Linq.JObject settingsObj)
-                updatedConfig.Settings = settingsObj.ToObject<SettingsConfig>(serializer) ?? new SettingsConfig();
-            if (currentObj["WebUI"] is Newtonsoft.Json.Linq.JObject webuiObj)
-                updatedConfig.WebUI = webuiObj.ToObject<WebUIConfig>(serializer) ?? new WebUIConfig();
-
-            foreach (var prop in currentObj.Properties())
-            {
-                if (prop.Value is not Newtonsoft.Json.Linq.JObject sectionObj) continue;
-                var lower = prop.Name.ToLowerInvariant();
-                bool isRadarr = lower == "radarr" || lower.StartsWith("radarr-");
-                bool isSonarr = lower == "sonarr" || lower.StartsWith("sonarr-");
-                bool isLidarr = lower == "lidarr" || lower.StartsWith("lidarr-");
-                bool isQbit = lower == "qbit" || lower.StartsWith("qbit-");
-                if (isRadarr || isSonarr || isLidarr)
-                {
-                    var arrConfig = sectionObj.ToObject<ArrInstanceConfig>(serializer) ?? new ArrInstanceConfig();
-                    if (string.IsNullOrEmpty(arrConfig.Type))
-                        arrConfig.Type = isRadarr ? "radarr" : isSonarr ? "sonarr" : "lidarr";
-                    updatedConfig.ArrInstances[prop.Name] = arrConfig;
-                }
-                else if (isQbit)
-                {
-                    updatedConfig.QBitInstances[prop.Name] = sectionObj.ToObject<QBitConfig>(serializer) ?? new QBitConfig();
-                }
-            }
-
-            var (reloadType, affectedInstancesList) = DetermineReloadType(cfg, updatedConfig);
-
-            loader.SaveConfig(updatedConfig);
-            cfg.Settings = updatedConfig.Settings;
-            cfg.WebUI = updatedConfig.WebUI;
-            cfg.ArrInstances = updatedConfig.ArrInstances;
-            cfg.QBitInstances = updatedConfig.QBitInstances;
-            return Results.Ok(new
-            {
-                status = "ok",
-                configReloaded = reloadType != "none" && reloadType != "frontend",
-                reloadType,
-                affectedInstances = affectedInstancesList
-            });
+            return SaveAndRespondConfigUpdate(cfg, updatedConfig, loader);
         }
         catch (Exception ex)
         {
@@ -2171,30 +2065,24 @@ try
         try
         {
             var payload = await request.ReadFromJsonAsync<System.Text.Json.JsonElement>();
-            string configJson;
+            TorrentarrConfig? updatedConfig;
             if (payload.TryGetProperty("changes", out var changesEl))
-                configJson = changesEl.GetRawText();
+            {
+                var changesObj = Newtonsoft.Json.Linq.JObject.Parse(changesEl.GetRawText());
+                var (mergedConfig, applyError) = ApplyDottedConfigChanges(cfg, changesObj);
+                if (applyError != null)
+                    return applyError;
+                updatedConfig = mergedConfig;
+            }
             else
-                configJson = payload.GetRawText();
-            var updatedConfig = Newtonsoft.Json.JsonConvert.DeserializeObject<TorrentarrConfig>(configJson);
+            {
+                updatedConfig = Newtonsoft.Json.JsonConvert.DeserializeObject<TorrentarrConfig>(payload.GetRawText());
+            }
+
             if (updatedConfig == null)
                 return Results.BadRequest(new { error = "Invalid config payload" });
 
-            // Determine reload type by comparing old vs new config before applying
-            var (reloadType, affectedInstancesList) = DetermineReloadType(cfg, updatedConfig);
-
-            loader.SaveConfig(updatedConfig);
-            cfg.Settings = updatedConfig.Settings;
-            cfg.WebUI = updatedConfig.WebUI;
-            cfg.ArrInstances = updatedConfig.ArrInstances;
-            cfg.QBitInstances = updatedConfig.QBitInstances;
-            return Results.Ok(new
-            {
-                status = "ok",
-                configReloaded = reloadType != "none" && reloadType != "frontend",
-                reloadType,
-                affectedInstances = affectedInstancesList
-            });
+            return SaveAndRespondConfigUpdate(cfg, updatedConfig, loader);
         }
         catch (Exception ex)
         {
@@ -2514,6 +2402,125 @@ static async Task<IResult> HandleTestConnection(TestConnectionRequest req, Torre
     }
 }
 
+static Newtonsoft.Json.JsonSerializerSettings CreateConfigMergeSerializerSettings() => new()
+{
+    ContractResolver = new Newtonsoft.Json.Serialization.DefaultContractResolver(),
+    NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
+    ObjectCreationHandling = Newtonsoft.Json.ObjectCreationHandling.Replace,
+};
+
+/// <summary>
+/// Apply dotted-key config changes onto the current in-memory config snapshot.
+/// Used by POST /web/config and POST /api/config when a <c>changes</c> object is supplied.
+/// </summary>
+static (TorrentarrConfig? updatedConfig, IResult? error) ApplyDottedConfigChanges(
+    TorrentarrConfig cfg,
+    Newtonsoft.Json.Linq.JObject changesObj)
+{
+    var serializer = Newtonsoft.Json.JsonSerializer.Create(CreateConfigMergeSerializerSettings());
+
+    var currentObj = new Newtonsoft.Json.Linq.JObject();
+    currentObj["Settings"] = Newtonsoft.Json.Linq.JObject.FromObject(cfg.Settings, serializer);
+    currentObj["WebUI"] = Newtonsoft.Json.Linq.JObject.FromObject(cfg.WebUI, serializer);
+    foreach (var (key, qbit) in cfg.QBitInstances.Where(kv => kv.Value.Host != "CHANGE_ME"))
+        currentObj[key] = Newtonsoft.Json.Linq.JObject.FromObject(qbit, serializer);
+    foreach (var (key, arr) in cfg.ArrInstances)
+        currentObj[key] = Newtonsoft.Json.Linq.JObject.FromObject(arr, serializer);
+
+    foreach (var change in changesObj.Properties())
+    {
+        if (string.Equals(change.Name, "Settings.ConfigVersion", StringComparison.OrdinalIgnoreCase))
+            return (null, Results.Json(new { error = "Cannot modify protected configuration key: Settings.ConfigVersion" }, statusCode: 403));
+
+        if (IsSensitiveDottedKey(change.Name) &&
+            change.Value.Type == Newtonsoft.Json.Linq.JTokenType.String &&
+            change.Value.ToString() == REDACTED_PLACEHOLDER)
+            continue;
+
+        var parts = change.Name.Split('.');
+        var rawSectionKey = parts[0];
+        var sectionKey = currentObj.Properties()
+            .FirstOrDefault(p => p.Name.Equals(rawSectionKey, StringComparison.OrdinalIgnoreCase))?.Name
+            ?? rawSectionKey;
+        if (change.Value.Type == Newtonsoft.Json.Linq.JTokenType.Null)
+        {
+            if (parts.Length == 1)
+                currentObj.Remove(sectionKey);
+            else if (currentObj[sectionKey] is Newtonsoft.Json.Linq.JObject sect)
+                DeleteNestedToken(sect, parts, 1);
+        }
+        else if (parts.Length == 1)
+        {
+            currentObj[sectionKey] = change.Value;
+        }
+        else
+        {
+            if (currentObj[sectionKey] is not Newtonsoft.Json.Linq.JObject sect)
+            {
+                sect = new Newtonsoft.Json.Linq.JObject();
+                currentObj[sectionKey] = sect;
+            }
+            SetNestedToken(sect, parts, 1, change.Value);
+        }
+    }
+
+    foreach (var emptyProp in currentObj.Properties().ToList())
+    {
+        if (emptyProp.Value is Newtonsoft.Json.Linq.JObject emptyObj && !emptyObj.Properties().Any())
+            currentObj.Remove(emptyProp.Name);
+    }
+
+    var updatedConfig = new TorrentarrConfig();
+    if (currentObj["Settings"] is Newtonsoft.Json.Linq.JObject settingsObj)
+        updatedConfig.Settings = settingsObj.ToObject<SettingsConfig>(serializer) ?? new SettingsConfig();
+    if (currentObj["WebUI"] is Newtonsoft.Json.Linq.JObject webuiObj)
+        updatedConfig.WebUI = webuiObj.ToObject<WebUIConfig>(serializer) ?? new WebUIConfig();
+
+    foreach (var prop in currentObj.Properties())
+    {
+        if (prop.Value is not Newtonsoft.Json.Linq.JObject sectionObj) continue;
+        var lower = prop.Name.ToLowerInvariant();
+        bool isRadarr = lower == "radarr" || lower.StartsWith("radarr-");
+        bool isSonarr = lower == "sonarr" || lower.StartsWith("sonarr-");
+        bool isLidarr = lower == "lidarr" || lower.StartsWith("lidarr-");
+        bool isQbit = lower == "qbit" || lower.StartsWith("qbit-");
+        if (isRadarr || isSonarr || isLidarr)
+        {
+            var arrConfig = sectionObj.ToObject<ArrInstanceConfig>(serializer) ?? new ArrInstanceConfig();
+            if (string.IsNullOrEmpty(arrConfig.Type))
+                arrConfig.Type = isRadarr ? "radarr" : isSonarr ? "sonarr" : "lidarr";
+            updatedConfig.ArrInstances[prop.Name] = arrConfig;
+        }
+        else if (isQbit)
+        {
+            updatedConfig.QBitInstances[prop.Name] = sectionObj.ToObject<QBitConfig>(serializer) ?? new QBitConfig();
+        }
+    }
+
+    return (updatedConfig, null);
+}
+
+static IResult SaveAndRespondConfigUpdate(
+    TorrentarrConfig cfg,
+    TorrentarrConfig updatedConfig,
+    ConfigurationLoader loader)
+{
+    var (reloadType, affectedInstancesList) = DetermineReloadType(cfg, updatedConfig);
+
+    loader.SaveConfig(updatedConfig);
+    cfg.Settings = updatedConfig.Settings;
+    cfg.WebUI = updatedConfig.WebUI;
+    cfg.ArrInstances = updatedConfig.ArrInstances;
+    cfg.QBitInstances = updatedConfig.QBitInstances;
+    return Results.Ok(new
+    {
+        status = "ok",
+        configReloaded = reloadType != "none" && reloadType != "frontend",
+        reloadType,
+        affectedInstances = affectedInstancesList
+    });
+}
+
 /// <summary>
 /// Recursively redact string values whose keys match <see cref="SensitiveKeyPatternRegex"/>.
 /// Returns a new JToken with sensitive values replaced by <see cref="REDACTED_PLACEHOLDER"/>.
@@ -2817,8 +2824,19 @@ class ProcessOrchestratorService : BackgroundService
                 return _config.Settings.CompletedDownloadFolder;
         }
 
-        // Final fallback: use /config which is always available in container
-        return "/config";
+        // Fall back to qBit download paths (Docker mounts torrents separately from /config)
+        foreach (var (_, qbit) in _config.QBitInstances)
+        {
+            if (qbit.Disabled)
+                continue;
+            var path = qbit.DownloadPath;
+            if (string.IsNullOrWhiteSpace(path) || path == "CHANGE_ME")
+                continue;
+            if (Directory.Exists(path))
+                return path;
+        }
+
+        return null;
     }
 
     private async Task ProcessSpecialCategoriesAsync(CancellationToken cancellationToken)

--- a/src/Torrentarr.Host/Program.cs
+++ b/src/Torrentarr.Host/Program.cs
@@ -3330,7 +3330,7 @@ class ProcessOrchestratorService : BackgroundService
         const string freeSpacePausedTag = "qBitrr-free_space_paused";
         var tagless = _config.Settings.Tagless;
 
-        var isDownloading = TorrentPolicyHelper.IsActiveDownloadingStateForFreeSpace(torrent.State);
+        var isFreeSpaceDownload = TorrentPolicyHelper.IsFreeSpaceDownloadState(torrent.State);
         var isPausedDownload = TorrentPolicyHelper.IsPausedDownloadStateForFreeSpace(torrent.State);
 
         // §1.6: tagless mode reads FreeSpacePaused from DB column; otherwise check qBit tag
@@ -3346,7 +3346,7 @@ class ProcessOrchestratorService : BackgroundService
             hasFreeSpaceTag = torrent.Tags?.Contains(freeSpacePausedTag) == true;
         }
 
-        if (isDownloading || (isPausedDownload && hasFreeSpaceTag))
+        if (isFreeSpaceDownload)
         {
             var freeSpaceTest = _currentFreeSpace - torrent.AmountLeft;
 
@@ -3368,7 +3368,18 @@ class ProcessOrchestratorService : BackgroundService
                 if (pausedCountRef != null) pausedCountRef[0]++;
                 await client.PauseTorrentAsync(torrent.Hash, cancellationToken);
             }
-            else if (isPausedDownload && freeSpaceTest >= 0)
+            else if (isPausedDownload && freeSpaceTest < 0)
+            {
+                _logger.LogInformation(
+                    "FreeSpace: Keeping paused (insufficient space) | Torrent: {Name} | Available: {Available} | Needed: {Needed} | Deficit: {Deficit}",
+                    torrent.Name, FormatBytes(_currentFreeSpace), FormatBytes(torrent.AmountLeft), FormatBytes(-freeSpaceTest));
+                if (tagless && dbContext != null)
+                    await dbContext.TorrentLibrary.Where(t => t.Hash == torrent.Hash)
+                        .ExecuteUpdateAsync(s => s.SetProperty(t => t.FreeSpacePaused, true), cancellationToken);
+                else
+                    await client.AddTagsAsync(new List<string> { torrent.Hash }, new List<string> { freeSpacePausedTag }, cancellationToken);
+            }
+            else if (isPausedDownload && freeSpaceTest >= 0 && hasFreeSpaceTag)
             {
                 _logger.LogInformation(
                     "FreeSpace: Resuming download (space available) | Torrent: {Name} | Available: {Available} | Space after: {SpaceAfter}",
@@ -3383,12 +3394,6 @@ class ProcessOrchestratorService : BackgroundService
                 if (pausedCountRef != null) pausedCountRef[0]--;
                 await client.ResumeTorrentAsync(torrent.Hash, cancellationToken);
             }
-            else if (isPausedDownload && freeSpaceTest < 0)
-            {
-                _logger.LogInformation(
-                    "FreeSpace: Keeping paused (insufficient space) | Torrent: {Name} | Available: {Available} | Needed: {Needed} | Deficit: {Deficit}",
-                    torrent.Name, FormatBytes(_currentFreeSpace), FormatBytes(torrent.AmountLeft), FormatBytes(-freeSpaceTest));
-            }
             else if (!isPausedDownload && freeSpaceTest >= 0)
             {
                 _logger.LogInformation(
@@ -3397,7 +3402,7 @@ class ProcessOrchestratorService : BackgroundService
                 _currentFreeSpace = freeSpaceTest;
             }
         }
-        else if (!isDownloading && hasFreeSpaceTag)
+        else if (!isFreeSpaceDownload && hasFreeSpaceTag)
         {
             // Torrent completed — clear the paused marker
             _logger.LogInformation(

--- a/src/Torrentarr.Host/Program.cs
+++ b/src/Torrentarr.Host/Program.cs
@@ -2911,13 +2911,13 @@ class ProcessOrchestratorService : BackgroundService
             _currentFreeSpace = driveInfo.AvailableFreeSpace - _minFreeSpaceBytes;
 
             // Gather torrents from ALL qBit instances across all managed categories, sorted by added date
-            var allTorrents = new List<(QBittorrentClient client, TorrentInfo torrent)>();
-            foreach (var (_, client) in _qbitManager.GetAllClients())
+            var allTorrents = new List<(string instanceName, QBittorrentClient client, TorrentInfo torrent)>();
+            foreach (var (instanceName, client) in _qbitManager.GetAllClients())
             {
                 foreach (var category in _managedCategories)
                 {
                     var torrents = await client.GetTorrentsAsync(category, cancellationToken);
-                    allTorrents.AddRange(torrents.Select(t => (client, t)));
+                    allTorrents.AddRange(torrents.Select(t => (instanceName, client, t)));
                 }
             }
 
@@ -2928,8 +2928,8 @@ class ProcessOrchestratorService : BackgroundService
                 pausedCountRef = new int[] { pausedCount };
             }
 
-            foreach (var (client, torrent) in allTorrents.OrderBy(x => x.torrent.AddedOn))
-                await ProcessSingleTorrentSpaceAsync(client, torrent, dbContext, pausedCountRef, cancellationToken);
+            foreach (var (instanceName, client, torrent) in allTorrents.OrderBy(x => x.torrent.AddedOn))
+                await ProcessSingleTorrentSpaceAsync(instanceName, client, torrent, dbContext, pausedCountRef, cancellationToken);
 
             if (_config.Settings.Tagless && dbContext != null)
                 pausedCount = await dbContext.TorrentLibrary.CountAsync(t => t.FreeSpacePaused, cancellationToken);
@@ -2954,7 +2954,7 @@ class ProcessOrchestratorService : BackgroundService
     }
 
     private async Task ProcessSingleTorrentSpaceAsync(
-        QBittorrentClient client, TorrentInfo torrent, TorrentarrDbContext? dbContext, int[]? pausedCountRef, CancellationToken cancellationToken)
+        string instanceName, QBittorrentClient client, TorrentInfo torrent, TorrentarrDbContext? dbContext, int[]? pausedCountRef, CancellationToken cancellationToken)
     {
         const string freeSpacePausedTag = "qBitrr-free_space_paused";
         var tagless = _config.Settings.Tagless;
@@ -2991,8 +2991,8 @@ class ProcessOrchestratorService : BackgroundService
                     torrent.Name, FormatBytes(_currentFreeSpace), FormatBytes(torrent.AmountLeft), FormatBytes(-freeSpaceTest));
                 // §1.6: tagless — set DB column; else apply qBit tag
                 if (tagless && dbContext != null)
-                    await dbContext.TorrentLibrary.Where(t => t.Hash == torrent.Hash)
-                        .ExecuteUpdateAsync(s => s.SetProperty(t => t.FreeSpacePaused, true), cancellationToken);
+                    await TaglessTorrentLibraryHelper.SetFreeSpacePausedAsync(
+                        dbContext, torrent.Hash, torrent.Category, instanceName, paused: true, cancellationToken);
                 else
                     await client.AddTagsAsync(new List<string> { torrent.Hash }, new List<string> { freeSpacePausedTag }, cancellationToken);
                 if (pausedCountRef != null) pausedCountRef[0]++;
@@ -3006,8 +3006,8 @@ class ProcessOrchestratorService : BackgroundService
                 _currentFreeSpace = freeSpaceTest;
                 // §1.6: tagless — clear DB column; else remove qBit tag
                 if (tagless && dbContext != null)
-                    await dbContext.TorrentLibrary.Where(t => t.Hash == torrent.Hash)
-                        .ExecuteUpdateAsync(s => s.SetProperty(t => t.FreeSpacePaused, false), cancellationToken);
+                    await TaglessTorrentLibraryHelper.SetFreeSpacePausedAsync(
+                        dbContext, torrent.Hash, torrent.Category, instanceName, paused: false, cancellationToken);
                 else
                     await client.RemoveTagsAsync(new List<string> { torrent.Hash }, new List<string> { freeSpacePausedTag }, cancellationToken);
                 if (pausedCountRef != null) pausedCountRef[0]--;
@@ -3035,8 +3035,8 @@ class ProcessOrchestratorService : BackgroundService
                 torrent.Name, FormatBytes(_currentFreeSpace + _minFreeSpaceBytes));
             // §1.6: tagless — clear DB column; else remove qBit tag
             if (tagless && dbContext != null)
-                await dbContext.TorrentLibrary.Where(t => t.Hash == torrent.Hash)
-                    .ExecuteUpdateAsync(s => s.SetProperty(t => t.FreeSpacePaused, false), cancellationToken);
+                await TaglessTorrentLibraryHelper.SetFreeSpacePausedAsync(
+                    dbContext, torrent.Hash, torrent.Category, instanceName, paused: false, cancellationToken);
             else
                 await client.RemoveTagsAsync(new List<string> { torrent.Hash }, new List<string> { freeSpacePausedTag }, cancellationToken);
             if (pausedCountRef != null) pausedCountRef[0]--;

--- a/src/Torrentarr.Host/Program.cs
+++ b/src/Torrentarr.Host/Program.cs
@@ -189,8 +189,8 @@ try
             options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
             if (!string.IsNullOrEmpty(urlBase))
                 options.Cookie.Path = urlBase + "/";
-            options.LoginPath = "/login";
-            options.AccessDeniedPath = "/login";
+            options.LoginPath = UrlBaseHelper.WithUrlBase(urlBase, "/login");
+            options.AccessDeniedPath = UrlBaseHelper.WithUrlBase(urlBase, "/login");
         });
     if (config.WebUI.OIDCEnabled && config.WebUI.OIDC is { } oidc
         && !string.IsNullOrWhiteSpace(oidc.Authority)
@@ -487,7 +487,8 @@ try
             await context.Response.WriteAsJsonAsync(new { error = "Unauthorized" });
             return;
         }
-        context.Response.Redirect("/login");
+        context.Response.Redirect(UrlBaseHelper.WithUrlBase(
+            UrlBaseHelper.NormalizeUrlBase(cfg.WebUI.UrlBase), "/login"));
     });
 
     static bool IsAuthRequired(TorrentarrConfig c) => !c.WebUI.AuthDisabled;
@@ -1412,15 +1413,17 @@ try
     });
 
     // Logout: sign out cookie and redirect to login (GET or POST for link/form compatibility).
-    app.MapGet("/web/logout", async (HttpContext ctx) =>
+    app.MapGet("/web/logout", async (HttpContext ctx, TorrentarrConfig cfg) =>
     {
         await ctx.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-        return Results.Redirect("/login", false);
+        return Results.Redirect(UrlBaseHelper.WithUrlBase(
+            UrlBaseHelper.NormalizeUrlBase(cfg.WebUI.UrlBase), "/login"), false);
     });
-    app.MapPost("/web/logout", async (HttpContext ctx) =>
+    app.MapPost("/web/logout", async (HttpContext ctx, TorrentarrConfig cfg) =>
     {
         await ctx.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-        return Results.Redirect("/login", false);
+        return Results.Redirect(UrlBaseHelper.WithUrlBase(
+            UrlBaseHelper.NormalizeUrlBase(cfg.WebUI.UrlBase), "/login"), false);
     });
 
     // Set password (first-time or reset): hash and write to config. Allowed when PasswordHash is empty or via setup token.

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/ArrApiException.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/ArrApiException.cs
@@ -1,0 +1,20 @@
+using System.Net;
+
+namespace Torrentarr.Infrastructure.ApiClients.Arr;
+
+/// <summary>
+/// Thrown when an Arr API request fails. Callers must not treat failures as empty data.
+/// </summary>
+public sealed class ArrApiException : Exception
+{
+    public ArrApiException(string message, HttpStatusCode? statusCode = null, string? errorMessage = null)
+        : base(message)
+    {
+        StatusCode = statusCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public HttpStatusCode? StatusCode { get; }
+
+    public string? ErrorMessage { get; }
+}

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/ArrClientResponse.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/ArrClientResponse.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using RestSharp;
+
+namespace Torrentarr.Infrastructure.ApiClients.Arr;
+
+internal static class ArrClientResponse
+{
+    internal static void EnsureSuccess(RestResponse response, string operation)
+    {
+        if (response.ResponseStatus != ResponseStatus.Completed)
+        {
+            throw new ArrApiException(
+                $"Arr API {operation} failed: {response.ResponseStatus}",
+                null,
+                response.ErrorMessage);
+        }
+
+        var statusCode = (int)response.StatusCode;
+        if (statusCode is >= 200 and < 300)
+            return;
+
+        var status = statusCode != 0
+            ? $"{statusCode} {response.StatusDescription}"
+            : response.ResponseStatus.ToString();
+
+        throw new ArrApiException(
+            $"Arr API {operation} failed: HTTP {status}",
+            statusCode != 0 ? (HttpStatusCode)statusCode : null,
+            response.ErrorMessage);
+    }
+}

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/LidarrClient.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/LidarrClient.cs
@@ -32,13 +32,12 @@ public class LidarrClient
         AddApiKeyHeader(request);
 
         var response = await _client.ExecuteAsync(request, ct);
+        ArrClientResponse.EnsureSuccess(response, "GET /api/v1/artist");
 
-        if (response.IsSuccessful && !string.IsNullOrEmpty(response.Content))
-        {
-            return JsonConvert.DeserializeObject<List<LidarrArtist>>(response.Content) ?? new List<LidarrArtist>();
-        }
+        if (string.IsNullOrEmpty(response.Content))
+            return new List<LidarrArtist>();
 
-        return new List<LidarrArtist>();
+        return JsonConvert.DeserializeObject<List<LidarrArtist>>(response.Content) ?? new List<LidarrArtist>();
     }
 
     /// <summary>
@@ -89,13 +88,12 @@ public class LidarrClient
             request.AddQueryParameter("artistId", artistId.Value.ToString());
 
         var response = await _client.ExecuteAsync(request, ct);
+        ArrClientResponse.EnsureSuccess(response, "GET /api/v1/album");
 
-        if (response.IsSuccessful && !string.IsNullOrEmpty(response.Content))
-        {
-            return JsonConvert.DeserializeObject<List<LidarrAlbum>>(response.Content) ?? new List<LidarrAlbum>();
-        }
+        if (string.IsNullOrEmpty(response.Content))
+            return new List<LidarrAlbum>();
 
-        return new List<LidarrAlbum>();
+        return JsonConvert.DeserializeObject<List<LidarrAlbum>>(response.Content) ?? new List<LidarrAlbum>();
     }
 
     /// <summary>
@@ -206,13 +204,12 @@ public class LidarrClient
         request.AddQueryParameter("pageSize", pageSize.ToString());
 
         var response = await _client.ExecuteAsync(request, ct);
+        ArrClientResponse.EnsureSuccess(response, "GET /api/v1/queue");
 
-        if (response.IsSuccessful && !string.IsNullOrEmpty(response.Content))
-        {
-            return JsonConvert.DeserializeObject<LidarrQueueResponse>(response.Content) ?? new LidarrQueueResponse();
-        }
+        if (string.IsNullOrEmpty(response.Content))
+            return new LidarrQueueResponse();
 
-        return new LidarrQueueResponse();
+        return JsonConvert.DeserializeObject<LidarrQueueResponse>(response.Content) ?? new LidarrQueueResponse();
     }
 
     /// <summary>
@@ -295,13 +292,12 @@ public class LidarrClient
             request.AddQueryParameter("albumId", albumId.Value.ToString());
 
         var response = await _client.ExecuteAsync(request, ct);
+        ArrClientResponse.EnsureSuccess(response, "GET /api/v1/track");
 
-        if (response.IsSuccessful && !string.IsNullOrEmpty(response.Content))
-        {
-            return JsonConvert.DeserializeObject<List<Track>>(response.Content) ?? new List<Track>();
-        }
+        if (string.IsNullOrEmpty(response.Content))
+            return new List<Track>();
 
-        return new List<Track>();
+        return JsonConvert.DeserializeObject<List<Track>>(response.Content) ?? new List<Track>();
     }
 
     /// <summary>

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/RadarrClient.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/RadarrClient.cs
@@ -32,13 +32,12 @@ public class RadarrClient
         AddApiKeyHeader(request);
 
         var response = await _client.ExecuteAsync(request, ct);
+        ArrClientResponse.EnsureSuccess(response, "GET /api/v3/movie");
 
-        if (response.IsSuccessful && !string.IsNullOrEmpty(response.Content))
-        {
-            return JsonConvert.DeserializeObject<List<RadarrMovie>>(response.Content) ?? new List<RadarrMovie>();
-        }
+        if (string.IsNullOrEmpty(response.Content))
+            return new List<RadarrMovie>();
 
-        return new List<RadarrMovie>();
+        return JsonConvert.DeserializeObject<List<RadarrMovie>>(response.Content) ?? new List<RadarrMovie>();
     }
 
     /// <summary>
@@ -170,13 +169,12 @@ public class RadarrClient
         request.AddQueryParameter("pageSize", pageSize.ToString());
 
         var response = await _client.ExecuteAsync(request, ct);
+        ArrClientResponse.EnsureSuccess(response, "GET /api/v3/queue");
 
-        if (response.IsSuccessful && !string.IsNullOrEmpty(response.Content))
-        {
-            return JsonConvert.DeserializeObject<QueueResponse>(response.Content) ?? new QueueResponse();
-        }
+        if (string.IsNullOrEmpty(response.Content))
+            return new QueueResponse();
 
-        return new QueueResponse();
+        return JsonConvert.DeserializeObject<QueueResponse>(response.Content) ?? new QueueResponse();
     }
 
     /// <summary>

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/SonarrClient.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/SonarrClient.cs
@@ -32,13 +32,12 @@ public class SonarrClient
         AddApiKeyHeader(request);
 
         var response = await _client.ExecuteAsync(request, ct);
+        ArrClientResponse.EnsureSuccess(response, "GET /api/v3/series");
 
-        if (response.IsSuccessful && !string.IsNullOrEmpty(response.Content))
-        {
-            return JsonConvert.DeserializeObject<List<SonarrSeries>>(response.Content) ?? new List<SonarrSeries>();
-        }
+        if (string.IsNullOrEmpty(response.Content))
+            return new List<SonarrSeries>();
 
-        return new List<SonarrSeries>();
+        return JsonConvert.DeserializeObject<List<SonarrSeries>>(response.Content) ?? new List<SonarrSeries>();
     }
 
     /// <summary>
@@ -88,13 +87,12 @@ public class SonarrClient
         request.AddQueryParameter("includeEpisodeFile", "true");
 
         var response = await _client.ExecuteAsync(request, ct);
+        ArrClientResponse.EnsureSuccess(response, "GET /api/v3/episode");
 
-        if (response.IsSuccessful && !string.IsNullOrEmpty(response.Content))
-        {
-            return JsonConvert.DeserializeObject<List<SonarrEpisode>>(response.Content) ?? new List<SonarrEpisode>();
-        }
+        if (string.IsNullOrEmpty(response.Content))
+            return new List<SonarrEpisode>();
 
-        return new List<SonarrEpisode>();
+        return JsonConvert.DeserializeObject<List<SonarrEpisode>>(response.Content) ?? new List<SonarrEpisode>();
     }
 
     /// <summary>
@@ -192,13 +190,12 @@ public class SonarrClient
         request.AddQueryParameter("pageSize", pageSize.ToString());
 
         var response = await _client.ExecuteAsync(request, ct);
+        ArrClientResponse.EnsureSuccess(response, "GET /api/v3/queue");
 
-        if (response.IsSuccessful && !string.IsNullOrEmpty(response.Content))
-        {
-            return JsonConvert.DeserializeObject<SonarrQueueResponse>(response.Content) ?? new SonarrQueueResponse();
-        }
+        if (string.IsNullOrEmpty(response.Content))
+            return new SonarrQueueResponse();
 
-        return new SonarrQueueResponse();
+        return JsonConvert.DeserializeObject<SonarrQueueResponse>(response.Content) ?? new SonarrQueueResponse();
     }
 
     /// <summary>

--- a/src/Torrentarr.Infrastructure/Services/ArrImportService.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrImportService.cs
@@ -353,7 +353,7 @@ public class ArrImportService : IArrImportService
             kv.Value == config).Key ?? "";
 
         var modelEntry = await _dbContext.Movies.AsNoTracking()
-            .FirstOrDefaultAsync(m => m.EntryId == record.MovieId && m.ArrInstance == arrName, ct);
+            .FirstOrDefaultAsync(m => m.ArrId == record.MovieId && m.ArrInstance == arrName, ct);
 
         if (modelEntry == null)
             return false;
@@ -389,7 +389,7 @@ public class ArrImportService : IArrImportService
             if (record.SeriesId == null) return false;
 
             var seriesEntry = await _dbContext.Series.AsNoTracking()
-                .FirstOrDefaultAsync(s => s.EntryId == record.SeriesId && s.ArrInstance == arrName, ct);
+                .FirstOrDefaultAsync(s => s.ArrId == record.SeriesId && s.ArrInstance == arrName, ct);
 
             if (seriesEntry == null) return false;
 
@@ -403,7 +403,7 @@ public class ArrImportService : IArrImportService
             if (record.EpisodeId == null) return false;
 
             var episodeEntry = await _dbContext.Episodes.AsNoTracking()
-                .FirstOrDefaultAsync(e => e.EntryId == record.EpisodeId && e.ArrInstance == arrName, ct);
+                .FirstOrDefaultAsync(e => e.ArrId == record.EpisodeId && e.ArrInstance == arrName, ct);
 
             if (episodeEntry == null) return false;
 
@@ -433,7 +433,7 @@ public class ArrImportService : IArrImportService
             kv.Value == config).Key ?? "";
 
         var modelEntry = await _dbContext.Albums.AsNoTracking()
-            .FirstOrDefaultAsync(a => a.EntryId == record.AlbumId && a.ArrInstance == arrName, ct);
+            .FirstOrDefaultAsync(a => a.ArrId == record.AlbumId && a.ArrInstance == arrName, ct);
 
         if (modelEntry == null)
             return false;

--- a/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
@@ -222,7 +222,7 @@ public class ArrSyncService
         {
             _logger.LogTrace("DB Delete: Movie {Title} (TmdbId: {TmdbId}) removed from database", movie.Title, movie.TmdbId);
         }
-        if (toDelete.Count > 0)
+        if (toDelete.Count > 0 && !ShouldSkipDestructiveDelete(movies.Count, dbMovies.Count, instanceName, "movies"))
             _db.Movies.RemoveRange(toDelete);
 
         await _db.SaveChangesAsync(ct);
@@ -351,7 +351,7 @@ public class ArrSyncService
         {
             _logger.LogTrace("DB Delete: Series {Title} removed from database", series.Title);
         }
-        if (seriesToDelete.Count > 0)
+        if (seriesToDelete.Count > 0 && !ShouldSkipDestructiveDelete(seriesList.Count, dbSeries.Count, instanceName, "series"))
         {
             var deleteIds = seriesToDelete.Select(s => s.EntryId).ToList();
             var orphanedEps = await _db.Episodes
@@ -871,6 +871,14 @@ public class ArrSyncService
         var existingTracks = await _db.Tracks
             .Where(t => t.ArrInstance == instanceName)
             .ToListAsync(ct);
+
+        if (ShouldSkipDestructiveDelete(allTracks.Count, existingTracks.Count, instanceName, "tracks"))
+        {
+            _logger.LogDebug("[{Instance}] ArrSyncService: Lidarr {Name} track sync skipped (suspicious empty API response)",
+                instanceName, instanceName);
+            return;
+        }
+
         _db.Tracks.RemoveRange(existingTracks);
         await _db.SaveChangesAsync(ct);
 
@@ -1276,6 +1284,23 @@ public class ArrSyncService
         queue.TrackedDownloadStatus = item.TrackedDownloadStatus;
         queue.TrackedDownloadState = item.TrackedDownloadState;
         queue.CustomFormatScore = item.CustomFormatScore;
+    }
+
+    /// <summary>
+    /// Refuse delete-all / mass-delete when the Arr API returns an empty catalog but the local DB still has rows.
+    /// Prevents wiping SQLite on transient API failures or misconfigured responses.
+    /// </summary>
+    private bool ShouldSkipDestructiveDelete(int apiCount, int existingCount, string instanceName, string entityName)
+    {
+        if (apiCount == 0 && existingCount > 0)
+        {
+            _logger.LogWarning(
+                "[{Instance}] ArrSyncService: refusing destructive {Entity} sync — API returned no items but DB has {Count} rows",
+                instanceName, entityName, existingCount);
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
@@ -315,12 +315,16 @@ public class ArrSyncService
             ct.ThrowIfCancellationRequested();
             apiIds.Add(series.Id);
 
+            profileDict.TryGetValue(series.QualityProfileId, out var seriesProfile);
+            var seriesMinCfScore = seriesProfile?.MinCustomFormatScore ?? 0;
+
             if (dbSeries.TryGetValue(series.Id, out var existing))
             {
                 existing.Monitored = series.Monitored;
                 existing.TvdbId = series.TvdbId;
                 existing.QualityProfileId = series.QualityProfileId;
                 existing.ArrId = series.Id;
+                existing.MinCustomFormatScore = seriesMinCfScore;
                 _db.Series.Update(existing);
                 entityBySonarrId[series.Id] = existing;
                 seriesUpdated++;
@@ -335,7 +339,8 @@ public class ArrSyncService
                     TvdbId = series.TvdbId,
                     Monitored = series.Monitored,
                     QualityProfileId = series.QualityProfileId,
-                    ArrId = series.Id
+                    ArrId = series.Id,
+                    MinCustomFormatScore = seriesMinCfScore
                 };
                 _db.Series.Add(newSeries);
                 entityBySonarrId[series.Id] = newSeries;

--- a/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
@@ -718,7 +718,7 @@ public class ArrSyncService
         {
             _logger.LogTrace("DB Delete: Artist {Title} removed from database", artist.Title);
         }
-        if (artistsToDelete.Count > 0)
+        if (artistsToDelete.Count > 0 && !ShouldSkipDestructiveDelete(artists.Count, dbArtists.Count, instanceName, "artists"))
             _db.Artists.RemoveRange(artistsToDelete);
 
         await _db.SaveChangesAsync(ct);
@@ -798,7 +798,7 @@ public class ArrSyncService
         {
             _logger.LogTrace("DB Delete: Album {Title} removed from database", album.Title);
         }
-        if (albumsToDelete.Count > 0)
+        if (albumsToDelete.Count > 0 && !ShouldSkipDestructiveDelete(albums.Count, dbAlbums.Count, instanceName, "albums"))
         {
             var deleteIds = albumsToDelete.Select(a => a.EntryId).ToList();
             var orphanedTracks = await _db.Tracks

--- a/src/Torrentarr.Infrastructure/Services/FreeSpaceService.cs
+++ b/src/Torrentarr.Infrastructure/Services/FreeSpaceService.cs
@@ -335,17 +335,17 @@ public class FreeSpaceService : IFreeSpaceService
         TorrentInfo torrent,
         CancellationToken cancellationToken)
     {
-        var isDownloading = TorrentPolicyHelper.IsActiveDownloadingStateForFreeSpace(torrent.State);
+        var isFreeSpaceDownload = TorrentPolicyHelper.IsFreeSpaceDownloadState(torrent.State);
         var isPausedDownload = TorrentPolicyHelper.IsPausedDownloadStateForFreeSpace(torrent.State);
         var hasFreeSpaceTag = HasTag(torrent, FreeSpacePausedTag);
 
         _logger.LogTrace("FreeSpace: [{Name}] | State[{State}] | Progress[{Progress:P1}] | Size[{Size}] | AmountLeft[{AmountLeft}] | HasTag[{HasTag}] | Hash[{Hash}]",
             torrent.Name, torrent.State, torrent.Progress, FormatBytes(torrent.Size), FormatBytes(torrent.AmountLeft), hasFreeSpaceTag, torrent.Hash);
 
-        _logger.LogTrace("FreeSpace: [{Instance}] Torrent {Name}: State={State}, IsDownloading={IsDl}, IsPausedDownload={IsPausedDl}, HasFreeSpaceTag={HasTag}",
-            instanceName, torrent.Name, torrent.State, isDownloading, isPausedDownload, hasFreeSpaceTag);
+        _logger.LogTrace("FreeSpace: [{Instance}] Torrent {Name}: State={State}, IsFreeSpaceDownload={IsDl}, IsPausedDownload={IsPausedDl}, HasFreeSpaceTag={HasTag}",
+            instanceName, torrent.Name, torrent.State, isFreeSpaceDownload, isPausedDownload, hasFreeSpaceTag);
 
-        if (isDownloading || (isPausedDownload && hasFreeSpaceTag))
+        if (isFreeSpaceDownload)
         {
             var freeSpaceTest = _currentFreeSpace - torrent.AmountLeft;
 
@@ -403,7 +403,7 @@ public class FreeSpaceService : IFreeSpaceService
                 _logger.LogTrace("FreeSpace: [{Instance}] Clearing FreeSpacePaused on torrent {Hash}", instanceName, torrent.Hash);
                 await SetFreeSpacePausedTagAsync(client, torrent.Hash, false, cancellationToken);
             }
-            else if (isPausedDownload && freeSpaceTest >= 0)
+            else if (isPausedDownload && freeSpaceTest >= 0 && hasFreeSpaceTag)
             {
                 _logger.LogInformation(
                     "FreeSpace: [{Instance}] Resuming download [{Name}] | Available[{Available}] | SpaceAfter[{SpaceAfter}] | Hash[{Hash}]",
@@ -421,7 +421,7 @@ public class FreeSpaceService : IFreeSpaceService
                 await client.ResumeTorrentAsync(torrent.Hash, cancellationToken);
             }
         }
-        else if (!isDownloading && hasFreeSpaceTag)
+        else if (!isFreeSpaceDownload && hasFreeSpaceTag)
         {
             _logger.LogInformation(
                 "FreeSpace: [{Instance}] Completed, removing tag [{Name}] | Available[{Available}] | Hash[{Hash}]",
@@ -436,13 +436,6 @@ public class FreeSpaceService : IFreeSpaceService
         {
             _logger.LogTrace("FreeSpace: [{Instance}] No action needed for torrent {Name}", instanceName, torrent.Name);
         }
-    }
-
-    private bool IsDownloadingState(string state)
-    {
-        return state.Contains("downloading", StringComparison.OrdinalIgnoreCase) ||
-               state.Contains("stalledDL", StringComparison.OrdinalIgnoreCase) ||
-               state.Contains("metaDL", StringComparison.OrdinalIgnoreCase);
     }
 
     private bool HasTag(TorrentInfo torrent, string tag)

--- a/src/Torrentarr.Infrastructure/Services/FreeSpaceService.cs
+++ b/src/Torrentarr.Infrastructure/Services/FreeSpaceService.cs
@@ -335,8 +335,8 @@ public class FreeSpaceService : IFreeSpaceService
         TorrentInfo torrent,
         CancellationToken cancellationToken)
     {
-        var isDownloading = IsDownloadingState(torrent.State);
-        var isPausedDownload = torrent.State.Contains("pausedDL", StringComparison.OrdinalIgnoreCase);
+        var isDownloading = TorrentPolicyHelper.IsActiveDownloadingStateForFreeSpace(torrent.State);
+        var isPausedDownload = TorrentPolicyHelper.IsPausedDownloadStateForFreeSpace(torrent.State);
         var hasFreeSpaceTag = HasTag(torrent, FreeSpacePausedTag);
 
         _logger.LogTrace("FreeSpace: [{Name}] | State[{State}] | Progress[{Progress:P1}] | Size[{Size}] | AmountLeft[{AmountLeft}] | HasTag[{HasTag}] | Hash[{Hash}]",

--- a/src/Torrentarr.Infrastructure/Services/FreeSpaceService.cs
+++ b/src/Torrentarr.Infrastructure/Services/FreeSpaceService.cs
@@ -187,7 +187,7 @@ public class FreeSpaceService : IFreeSpaceService
                 {
                     try
                     {
-                        await SetFreeSpacePausedTagAsync(client, torrent.Hash, true, cancellationToken);
+                        await SetFreeSpacePausedTagAsync(client, torrent, instanceName, true, cancellationToken);
                         await client.PauseTorrentAsync(torrent.Hash, cancellationToken);
                         _logger.LogInformation("FreeSpace: [{Instance}] Paused torrent due to low space: {Name}", instanceName, torrent.Name);
                         paused = true;
@@ -226,7 +226,7 @@ public class FreeSpaceService : IFreeSpaceService
                 {
                     try
                     {
-                        await SetFreeSpacePausedTagAsync(client, torrent.Hash, false, cancellationToken);
+                        await SetFreeSpacePausedTagAsync(client, torrent, instanceName, false, cancellationToken);
                         await client.ResumeTorrentAsync(torrent.Hash, cancellationToken);
                         _logger.LogInformation("FreeSpace: [{Instance}] Resumed torrent: {Name}", instanceName, torrent.Name);
                         resumed = true;
@@ -369,7 +369,7 @@ public class FreeSpaceService : IFreeSpaceService
                     torrent.Hash);
 
                 _logger.LogTrace("FreeSpace: [{Instance}] Setting FreeSpacePaused on torrent {Hash}", instanceName, torrent.Hash);
-                await SetFreeSpacePausedTagAsync(client, torrent.Hash, true, cancellationToken);
+                await SetFreeSpacePausedTagAsync(client, torrent, instanceName, true, cancellationToken);
                 if (!_config.Settings.Tagless)
                     await client.RemoveTagsAsync(new List<string> { torrent.Hash }, new List<string> { AllowedSeedingTag }, cancellationToken);
                 _logger.LogTrace("FreeSpace: [{Instance}] Pausing torrent {Hash}", instanceName, torrent.Hash);
@@ -386,7 +386,7 @@ public class FreeSpaceService : IFreeSpaceService
                     torrent.Hash);
 
                 _logger.LogTrace("FreeSpace: [{Instance}] Maintaining FreeSpacePaused on torrent {Hash}", instanceName, torrent.Hash);
-                await SetFreeSpacePausedTagAsync(client, torrent.Hash, true, cancellationToken);
+                await SetFreeSpacePausedTagAsync(client, torrent, instanceName, true, cancellationToken);
                 if (!_config.Settings.Tagless)
                     await client.RemoveTagsAsync(new List<string> { torrent.Hash }, new List<string> { AllowedSeedingTag }, cancellationToken);
             }
@@ -401,7 +401,7 @@ public class FreeSpaceService : IFreeSpaceService
 
                 _currentFreeSpace = freeSpaceTest;
                 _logger.LogTrace("FreeSpace: [{Instance}] Clearing FreeSpacePaused on torrent {Hash}", instanceName, torrent.Hash);
-                await SetFreeSpacePausedTagAsync(client, torrent.Hash, false, cancellationToken);
+                await SetFreeSpacePausedTagAsync(client, torrent, instanceName, false, cancellationToken);
             }
             else if (isPausedDownload && freeSpaceTest >= 0)
             {
@@ -414,7 +414,7 @@ public class FreeSpaceService : IFreeSpaceService
 
                 _currentFreeSpace = freeSpaceTest;
                 _logger.LogTrace("FreeSpace: [{Instance}] Clearing FreeSpacePaused on torrent {Hash}", instanceName, torrent.Hash);
-                await SetFreeSpacePausedTagAsync(client, torrent.Hash, false, cancellationToken);
+                await SetFreeSpacePausedTagAsync(client, torrent, instanceName, false, cancellationToken);
                 if (!_config.Settings.Tagless)
                     await client.AddTagsAsync(new List<string> { torrent.Hash }, new List<string> { AllowedSeedingTag }, cancellationToken);
                 _logger.LogTrace("FreeSpace: [{Instance}] Resuming torrent {Hash}", instanceName, torrent.Hash);
@@ -430,7 +430,7 @@ public class FreeSpaceService : IFreeSpaceService
                 torrent.Hash);
 
             _logger.LogTrace("FreeSpace: [{Instance}] Clearing FreeSpacePaused on completed torrent {Hash}", instanceName, torrent.Hash);
-            await SetFreeSpacePausedTagAsync(client, torrent.Hash, false, cancellationToken);
+            await SetFreeSpacePausedTagAsync(client, torrent, instanceName, false, cancellationToken);
         }
         else
         {
@@ -462,21 +462,21 @@ public class FreeSpaceService : IFreeSpaceService
     }
 
     /// <summary>§1.6: Set or clear FreeSpacePaused — uses qBit tag or DB column based on Tagless setting.</summary>
-    private async Task SetFreeSpacePausedTagAsync(QBittorrentClient client, string hash, bool paused, CancellationToken ct)
+    private async Task SetFreeSpacePausedTagAsync(
+        QBittorrentClient client, TorrentInfo torrent, string instanceName, bool paused, CancellationToken ct)
     {
         if (_config.Settings.Tagless)
         {
-            await _dbContext.TorrentLibrary
-                .Where(t => t.Hash == hash)
-                .ExecuteUpdateAsync(s => s.SetProperty(t => t.FreeSpacePaused, paused), ct);
+            await TaglessTorrentLibraryHelper.SetFreeSpacePausedAsync(
+                _dbContext, torrent.Hash, torrent.Category, instanceName, paused, ct);
         }
         else if (paused)
         {
-            await client.AddTagsAsync(new List<string> { hash }, new List<string> { FreeSpacePausedTag }, ct);
+            await client.AddTagsAsync(new List<string> { torrent.Hash }, new List<string> { FreeSpacePausedTag }, ct);
         }
         else
         {
-            await client.RemoveTagsAsync(new List<string> { hash }, new List<string> { FreeSpacePausedTag }, ct);
+            await client.RemoveTagsAsync(new List<string> { torrent.Hash }, new List<string> { FreeSpacePausedTag }, ct);
         }
     }
 

--- a/src/Torrentarr.Infrastructure/Services/SeedingService.cs
+++ b/src/Torrentarr.Infrastructure/Services/SeedingService.cs
@@ -696,6 +696,14 @@ public class SeedingService : ISeedingService
                     continue;
                 }
 
+                if (!await HnrAllowsDeleteAsync(torrent, "removal criteria", cancellationToken))
+                {
+                    _logger.LogDebug("H&R: Keeping torrent [{Name}] - Hit and Run protection active | Ratio[{Ratio:F2}] | SeedingTime[{SeedingTime}s]",
+                        torrent.Name, torrent.Ratio, torrent.SeedingTime);
+                    result.TorrentsProtected++;
+                    continue;
+                }
+
                 var imported = await _dbContext.TorrentLibrary
                     .AnyAsync(t => t.Hash == torrent.Hash && t.Imported, cancellationToken);
 

--- a/src/Torrentarr.Infrastructure/Services/SeedingService.cs
+++ b/src/Torrentarr.Infrastructure/Services/SeedingService.cs
@@ -430,31 +430,34 @@ public class SeedingService : ISeedingService
 
     /// <summary>
     /// Check if HnR obligations allow deleting this torrent.
-    /// Fetches tracker metadata and checks HnR. Returns true if deletion is allowed.
-    /// Matches qBitrr's _hnr_allows_delete() exactly.
+    /// Uses matched tracker config when available, otherwise category seeding (same resolution as
+    /// <see cref="IsHitAndRunProtectedAsync"/>). Returns true if deletion is allowed.
     /// </summary>
     public async Task<bool> HnrAllowsDeleteAsync(TorrentInfo torrent, string reason, CancellationToken cancellationToken = default)
     {
-        var trackers = GetTrackerList(torrent);
-        var hasHnrTracker = trackers.Any(t => IsHnREnabled(t.HitAndRunMode));
-
-        if (!hasHnrTracker)
-        {
-            return true; // Fast path: no HnR on any tracker
-        }
-
         var trackerConfig = await GetTrackerConfigAsync(torrent, cancellationToken);
-        if (trackerConfig == null)
+        var hnrConfig = trackerConfig != null ? ConvertToCategorySeeding(trackerConfig) : GetSeedingConfig(torrent);
+
+        if (!IsHnREnabled(hnrConfig.HitAndRunMode))
         {
             return true;
         }
 
-        if (await IsTrackerDeadAsync(torrent, trackerConfig, cancellationToken))
+        if (trackerConfig != null && await IsTrackerDeadAsync(torrent, trackerConfig, cancellationToken))
         {
+            _logger.LogDebug("HnR bypass: tracker reports torrent as unregistered/dead '{Name}'", torrent.Name);
             return true;
         }
 
-        if (await IsHnRSafeToRemoveAsync(torrent, trackerConfig, cancellationToken))
+        if (await IsHnRSafeToRemoveAsync(torrent, trackerConfig ?? new TrackerConfig
+        {
+            HitAndRunMode = hnrConfig.HitAndRunMode,
+            MinSeedRatio = hnrConfig.MinSeedRatio,
+            MinSeedingTimeDays = hnrConfig.MinSeedingTimeDays,
+            HitAndRunMinimumDownloadPercent = hnrConfig.HitAndRunMinimumDownloadPercent,
+            HitAndRunPartialSeedRatio = hnrConfig.HitAndRunPartialSeedRatio,
+            TrackerUpdateBuffer = hnrConfig.TrackerUpdateBuffer
+        }, cancellationToken))
         {
             return true;
         }

--- a/src/Torrentarr.Infrastructure/Services/TaglessTorrentLibraryHelper.cs
+++ b/src/Torrentarr.Infrastructure/Services/TaglessTorrentLibraryHelper.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Torrentarr.Infrastructure.Database;
+using Torrentarr.Infrastructure.Database.Models;
+
+namespace Torrentarr.Infrastructure.Services;
+
+/// <summary>
+/// Tagless-mode helpers for persisting qBitrr tag semantics in TorrentLibrary columns.
+/// </summary>
+public static class TaglessTorrentLibraryHelper
+{
+    /// <summary>
+    /// Set <see cref="TorrentLibrary.FreeSpacePaused"/> in tagless mode.
+    /// When pausing, upserts a row if the torrent is not yet in the database — otherwise
+    /// the update is a no-op and TorrentProcessor resumes the free-space pause.
+    /// </summary>
+    public static async Task SetFreeSpacePausedAsync(
+        TorrentarrDbContext db,
+        string hash,
+        string category,
+        string qbitInstance,
+        bool paused,
+        CancellationToken ct = default)
+    {
+        var entry = await db.TorrentLibrary
+            .FirstOrDefaultAsync(t => t.Hash == hash && t.QbitInstance == qbitInstance, ct);
+
+        if (entry != null)
+        {
+            entry.FreeSpacePaused = paused;
+            await db.SaveChangesAsync(ct);
+            return;
+        }
+
+        if (paused)
+        {
+            db.TorrentLibrary.Add(new TorrentLibrary
+            {
+                Hash = hash,
+                Category = category,
+                QbitInstance = qbitInstance,
+                FreeSpacePaused = true
+            });
+            await db.SaveChangesAsync(ct);
+        }
+    }
+}

--- a/src/Torrentarr.Infrastructure/Services/TaglessTorrentLibraryHelper.cs
+++ b/src/Torrentarr.Infrastructure/Services/TaglessTorrentLibraryHelper.cs
@@ -32,15 +32,31 @@ public static class TaglessTorrentLibraryHelper
             return;
         }
 
-        if (paused)
+        if (!paused)
+            return;
+
+        db.TorrentLibrary.Add(new TorrentLibrary
         {
-            db.TorrentLibrary.Add(new TorrentLibrary
-            {
-                Hash = hash,
-                Category = category,
-                QbitInstance = qbitInstance,
-                FreeSpacePaused = true
-            });
+            Hash = hash,
+            Category = category,
+            QbitInstance = qbitInstance,
+            FreeSpacePaused = true
+        });
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            // TorrentProcessor.EnsureTorrentInDatabaseAsync may insert the same row concurrently.
+            db.ChangeTracker.Clear();
+            entry = await db.TorrentLibrary
+                .FirstOrDefaultAsync(t => t.Hash == hash && t.QbitInstance == qbitInstance, ct);
+            if (entry == null)
+                throw;
+
+            entry.FreeSpacePaused = true;
             await db.SaveChangesAsync(ct);
         }
     }

--- a/src/Torrentarr.Infrastructure/Services/WebUIAuthHelpers.cs
+++ b/src/Torrentarr.Infrastructure/Services/WebUIAuthHelpers.cs
@@ -55,9 +55,12 @@ public static class WebUIAuthHelpers
         if (isAuthenticated)
             return true;
 
+        // WebUI.Token as Bearer/query is for /api/* auth. Allow it for first-time bootstrap only;
+        // password resets require setupToken (env) or an authenticated session.
         if (!string.IsNullOrWhiteSpace(bearerOrQueryToken)
             && !string.IsNullOrWhiteSpace(cfg.WebUI.Token)
-            && TokenEquals(bearerOrQueryToken, cfg.WebUI.Token))
+            && TokenEquals(bearerOrQueryToken, cfg.WebUI.Token)
+            && string.IsNullOrEmpty(cfg.WebUI.PasswordHash))
             return true;
 
         if (string.IsNullOrWhiteSpace(setupToken))

--- a/src/Torrentarr.Infrastructure/Torrentarr.Infrastructure.csproj
+++ b/src/Torrentarr.Infrastructure/Torrentarr.Infrastructure.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="RestSharp" Version="114.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />

--- a/src/Torrentarr.WebUI/Program.cs
+++ b/src/Torrentarr.WebUI/Program.cs
@@ -737,6 +737,7 @@ app.MapPost("/web/config", async (HttpContext ctx, TorrentarrConfig config, Conf
 
         var updatedConfig = FlatToConfig(flatConfig, config);
         loader.SaveConfig(updatedConfig, reloader.ConfigPath);
+        ApplyConfigInPlace(config, updatedConfig);
     }
     catch (Exception ex)
     {
@@ -754,6 +755,15 @@ app.MapPost("/web/config", async (HttpContext ctx, TorrentarrConfig config, Conf
         affectedInstances
     });
 });
+
+static void ApplyConfigInPlace(TorrentarrConfig target, TorrentarrConfig source)
+{
+    target.Settings = source.Settings;
+    target.WebUI = source.WebUI;
+    target.ArrInstances = source.ArrInstances;
+    target.QBitInstances = source.QBitInstances;
+    TorrentPolicyHelper.InvalidateMonitoredPolicyCategoriesCache(target);
+}
 
 // Helper: apply a dot-path change to a JObject (e.g. "Settings.LoopSleepTimer" = 30)
 static void ApplyDotPathChange(Newtonsoft.Json.Linq.JObject root, string dotPath, Newtonsoft.Json.Linq.JToken value)
@@ -1471,11 +1481,12 @@ app.MapPost("/web/config/reload", (IConfigReloader reloader) =>
         : Results.BadRequest(new { success = false, message = "Failed to reload configuration" });
 });
 
-app.MapPost("/web/config/save", async (TorrentarrConfig updatedConfig, ConfigurationLoader loader, IConfigReloader reloader) =>
+app.MapPost("/web/config/save", async (TorrentarrConfig updatedConfig, TorrentarrConfig config, ConfigurationLoader loader, IConfigReloader reloader) =>
 {
     try
     {
         loader.SaveConfig(updatedConfig, reloader.ConfigPath);
+        ApplyConfigInPlace(config, updatedConfig);
         var reloadSuccess = reloader.ReloadConfig();
 
         return reloadSuccess

--- a/src/Torrentarr.WebUI/Program.cs
+++ b/src/Torrentarr.WebUI/Program.cs
@@ -162,8 +162,8 @@ var authBuilder = builder.Services.AddAuthentication(CookieAuthenticationDefault
         options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
         if (!string.IsNullOrEmpty(urlBase))
             options.Cookie.Path = urlBase + "/";
-        options.LoginPath = "/login";
-        options.AccessDeniedPath = "/login";
+        options.LoginPath = UrlBaseHelper.WithUrlBase(urlBase, "/login");
+        options.AccessDeniedPath = UrlBaseHelper.WithUrlBase(urlBase, "/login");
     });
 if (configForDI.WebUI.OIDCEnabled && configForDI.WebUI.OIDC is { } oidc
     && !string.IsNullOrWhiteSpace(oidc.Authority)
@@ -320,7 +320,9 @@ app.Use(async (context, next) =>
         await context.Response.WriteAsJsonAsync(new { error = "Unauthorized" });
         return;
     }
-    context.Response.Redirect("/login");
+    var cfgRedirect = context.RequestServices.GetRequiredService<TorrentarrConfig>();
+    context.Response.Redirect(UrlBaseHelper.WithUrlBase(
+        UrlBaseHelper.NormalizeUrlBase(cfgRedirect.WebUI.UrlBase), "/login"));
 });
 
 static bool WebUIAuthRequired(TorrentarrConfig c) => !c.WebUI.AuthDisabled;
@@ -373,15 +375,17 @@ app.MapPost("/web/login", async (HttpContext ctx, TorrentarrConfig cfg, IPasswor
 });
 
 // Logout: sign out cookie and redirect to login (GET or POST for link/form compatibility).
-app.MapGet("/web/logout", async (HttpContext ctx) =>
+app.MapGet("/web/logout", async (HttpContext ctx, TorrentarrConfig cfg) =>
 {
     await ctx.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-    return Results.Redirect("/login", false);
+    return Results.Redirect(UrlBaseHelper.WithUrlBase(
+        UrlBaseHelper.NormalizeUrlBase(cfg.WebUI.UrlBase), "/login"), false);
 });
-app.MapPost("/web/logout", async (HttpContext ctx) =>
+app.MapPost("/web/logout", async (HttpContext ctx, TorrentarrConfig cfg) =>
 {
     await ctx.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-    return Results.Redirect("/login", false);
+    return Results.Redirect(UrlBaseHelper.WithUrlBase(
+        UrlBaseHelper.NormalizeUrlBase(cfg.WebUI.UrlBase), "/login"), false);
 });
 
 app.MapPost("/web/auth/set-password", async (HttpContext ctx, TorrentarrConfig cfg, ConfigurationLoader loader, IPasswordHasher hasher) =>

--- a/src/Torrentarr.Workers/Torrentarr.Workers.csproj
+++ b/src/Torrentarr.Workers/Torrentarr.Workers.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>
 

--- a/tests/Torrentarr.Core.Tests/Configuration/ConfigurationLoaderTests.cs
+++ b/tests/Torrentarr.Core.Tests/Configuration/ConfigurationLoaderTests.cs
@@ -639,6 +639,39 @@ public class ConfigurationLoaderTests : IDisposable
     }
 
     [Fact]
+    public void SaveConfig_PreservesQBitTrackers()
+    {
+        WriteToml("""
+            [Settings]
+            LoopSleepTimer = 5
+
+            [qBit]
+            Host = "localhost"
+
+            [[qBit.Trackers]]
+            URI = "https://tracker.example.com/announce"
+            Priority = 10
+            SortTorrents = true
+            HitAndRunMode = "and"
+            MinSeedRatio = 2.0
+            """);
+
+        var loader = new ConfigurationLoader(_tempFilePath);
+        var config = loader.Load();
+        config.Settings.LoopSleepTimer = 10;
+        loader.SaveConfig(config);
+
+        var reloaded = new ConfigurationLoader(_tempFilePath).Load();
+        reloaded.QBitInstances["qBit"].Trackers.Should().ContainSingle();
+        reloaded.QBitInstances["qBit"].Trackers[0].Uri.Should().Be("https://tracker.example.com/announce");
+        reloaded.QBitInstances["qBit"].Trackers[0].SortTorrents.Should().BeTrue();
+        reloaded.QBitInstances["qBit"].Trackers[0].Priority.Should().Be(10);
+        reloaded.QBitInstances["qBit"].Trackers[0].HitAndRunMode.Should().Be("and");
+        reloaded.QBitInstances["qBit"].Trackers[0].MinSeedRatio.Should().Be(2.0);
+        reloaded.Settings.LoopSleepTimer.Should().Be(10);
+    }
+
+    [Fact]
     public void Save_WebUI_WritesAuthBooleans()
     {
         WriteToml("""

--- a/tests/Torrentarr.Core.Tests/Configuration/TorrentPolicyHelperTests.cs
+++ b/tests/Torrentarr.Core.Tests/Configuration/TorrentPolicyHelperTests.cs
@@ -124,6 +124,25 @@ public class TorrentPolicyHelperTests
         TorrentPolicyHelper.IsQueueSeedingForSort("stalledDL").Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData("downloading", true)]
+    [InlineData("stalledDL", true)]
+    [InlineData("metaDL", true)]
+    [InlineData("uploading", false)]
+    public void IsActiveDownloadingStateForFreeSpace_MatchesExpectedStates(string state, bool expected)
+    {
+        TorrentPolicyHelper.IsActiveDownloadingStateForFreeSpace(state).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("pausedDL", true)]
+    [InlineData("stoppedDL", true)]
+    [InlineData("downloading", false)]
+    public void IsPausedDownloadStateForFreeSpace_MatchesExpectedStates(string state, bool expected)
+    {
+        TorrentPolicyHelper.IsPausedDownloadStateForFreeSpace(state).Should().Be(expected);
+    }
+
     [Fact]
     public void IsMonitoredPolicyCategory_IncludesArrAndQBitManaged()
     {

--- a/tests/Torrentarr.Core.Tests/Configuration/TorrentPolicyHelperTests.cs
+++ b/tests/Torrentarr.Core.Tests/Configuration/TorrentPolicyHelperTests.cs
@@ -127,6 +127,8 @@ public class TorrentPolicyHelperTests
     [Theory]
     [InlineData("downloading", true)]
     [InlineData("stalledDL", true)]
+    [InlineData("queuedDL", true)]
+    [InlineData("forcedDL", true)]
     [InlineData("metaDL", true)]
     [InlineData("uploading", false)]
     public void IsActiveDownloadingStateForFreeSpace_MatchesExpectedStates(string state, bool expected)
@@ -141,6 +143,18 @@ public class TorrentPolicyHelperTests
     public void IsPausedDownloadStateForFreeSpace_MatchesExpectedStates(string state, bool expected)
     {
         TorrentPolicyHelper.IsPausedDownloadStateForFreeSpace(state).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("downloading", true)]
+    [InlineData("queuedDL", true)]
+    [InlineData("forcedDL", true)]
+    [InlineData("pausedDL", true)]
+    [InlineData("stoppedDL", true)]
+    [InlineData("uploading", false)]
+    public void IsFreeSpaceDownloadState_MatchesQbitrrDownloadStates(string state, bool expected)
+    {
+        TorrentPolicyHelper.IsFreeSpaceDownloadState(state).Should().Be(expected);
     }
 
     [Fact]

--- a/tests/Torrentarr.Core.Tests/Configuration/UrlBaseHelperTests.cs
+++ b/tests/Torrentarr.Core.Tests/Configuration/UrlBaseHelperTests.cs
@@ -24,4 +24,19 @@ public class UrlBaseHelperTests
     {
         UrlBaseHelper.NormalizeUrlBase(42).Should().Be("/42");
     }
+
+    [Theory]
+    [InlineData("", "/login", "/login")]
+    [InlineData("/torrentarr", "/login", "/torrentarr/login")]
+    [InlineData("/torrentarr", "login", "/torrentarr/login")]
+    public void WithUrlBase_PrefixesConfiguredBase(string urlBase, string path, string expected)
+    {
+        UrlBaseHelper.WithUrlBase(urlBase, path).Should().Be(expected);
+    }
+
+    [Fact]
+    public void WithUrlBase_HandlesRequestStylePathBase()
+    {
+        UrlBaseHelper.WithUrlBase("/torrentarr", "/login").Should().Be("/torrentarr/login");
+    }
 }

--- a/tests/Torrentarr.Host.Tests/Api/ConfigEndpointTests.cs
+++ b/tests/Torrentarr.Host.Tests/Api/ConfigEndpointTests.cs
@@ -144,6 +144,32 @@ public class ConfigEndpointTests : IClassFixture<TorrentarrWebApplicationFactory
         var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
         json.GetProperty("reloadType").GetString().Should().Be("full");
     }
+
+    [Fact]
+    public async Task PostApiConfig_WithChanges_PreservesUnchangedSections()
+    {
+        var client = _factory.CreateClientWithApiToken();
+        var before = await client.GetAsync("/web/config");
+        before.StatusCode.Should().Be(HttpStatusCode.OK);
+        var beforeJson = JsonDocument.Parse(await before.Content.ReadAsStringAsync()).RootElement;
+        beforeJson.TryGetProperty("WebUI", out _).Should().BeTrue();
+        var originalPort = beforeJson.GetProperty("WebUI").GetProperty("Port").GetInt32();
+
+        var payload = new
+        {
+            changes = new Dictionary<string, object>
+            {
+                ["Settings.LoopSleepTimer"] = 42
+            }
+        };
+        var patchResponse = await client.PostAsJsonAsync("/api/config", payload);
+        patchResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var after = await client.GetAsync("/web/config");
+        var afterJson = JsonDocument.Parse(await after.Content.ReadAsStringAsync()).RootElement;
+        afterJson.GetProperty("Settings").GetProperty("LoopSleepTimer").GetInt32().Should().Be(42);
+        afterJson.GetProperty("WebUI").GetProperty("Port").GetInt32().Should().Be(originalPort);
+    }
 }
 
 /// <summary>

--- a/tests/Torrentarr.Host.Tests/Api/SetPasswordEndpointTests.cs
+++ b/tests/Torrentarr.Host.Tests/Api/SetPasswordEndpointTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
@@ -106,6 +107,52 @@ public class SetPasswordEndpointTests : IClassFixture<TorrentarrWebApplicationFa
                 password = "otherPassword"
             });
             response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+        finally
+        {
+            factory.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task PostSetPassword_WhenPasswordAlreadySet_WithBearerApiToken_Returns403()
+    {
+        var factory = new LocalAuthWebApplicationFactory();
+        try
+        {
+            factory.SetConfigEnv();
+            var client = factory.CreateClientWithoutApiToken();
+            client.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", "test-api-token");
+            var response = await client.PostAsJsonAsync("/web/auth/set-password", new
+            {
+                username = "attacker",
+                password = "newPassword123"
+            });
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+        finally
+        {
+            factory.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task PostSetPassword_WhenNoPasswordSet_WithBearerApiToken_Returns200()
+    {
+        var factory = new LocalAuthNoPasswordWebApplicationFactory();
+        try
+        {
+            factory.SetConfigEnv();
+            var client = factory.CreateClientWithoutApiToken();
+            client.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", "test-api-token");
+            var response = await client.PostAsJsonAsync("/web/auth/set-password", new
+            {
+                username = "admin",
+                password = "newPassword123"
+            });
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {

--- a/tests/Torrentarr.Host.Tests/Api/TorrentarrWebApplicationFactory.cs
+++ b/tests/Torrentarr.Host.Tests/Api/TorrentarrWebApplicationFactory.cs
@@ -434,6 +434,33 @@ public class UrlBaseWebApplicationFactory : TorrentarrWebApplicationFactory
         """;
 }
 
+/// <summary>UrlBase + auth required (browser redirect to login under path base).</summary>
+public class UrlBaseAuthWebApplicationFactory : TorrentarrWebApplicationFactory
+{
+    public UrlBaseAuthWebApplicationFactory() => RewriteConfigFile();
+
+    protected override string GetTestConfigToml() => """
+        [Settings]
+        ConfigVersion = "6.12.2"
+        LoopSleepTimer = 5
+        FailedCategory = "failed"
+        RecheckCategory = "recheck"
+        PingURLS = ["one.one.one.one"]
+
+        [WebUI]
+        Host = "0.0.0.0"
+        Port = 6969
+        Token = "test-api-token"
+        AuthDisabled = false
+        LocalAuthEnabled = true
+        OIDCEnabled = false
+        Username = "admin"
+        PasswordHash = "$2a$11$testhash"
+        LiveArr = false
+        UrlBase = "torrentarr"
+        """;
+}
+
 /// <summary>Shared DB seed helpers for catalog rollup and browse endpoint tests.</summary>
 public static class CatalogTestDataSeeder
 {

--- a/tests/Torrentarr.Host.Tests/Api/UrlBaseEndpointTests.cs
+++ b/tests/Torrentarr.Host.Tests/Api/UrlBaseEndpointTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
 using System.Net;
 using System.Text.Json;
 using Xunit;
@@ -60,5 +61,33 @@ public class UrlBaseEndpointTests : IClassFixture<UrlBaseWebApplicationFactory>
         var client = _factory.CreateClientWithPathBase("/torrentarr", withApiToken: false);
         var response = await client.GetAsync("/web/meta");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}
+
+[Collection("HostWebUrlBase")]
+public class UrlBaseAuthRedirectEndpointTests : IClassFixture<UrlBaseAuthWebApplicationFactory>
+{
+    private readonly UrlBaseAuthWebApplicationFactory _factory;
+
+    public UrlBaseAuthRedirectEndpointTests(UrlBaseAuthWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetProtected_WithoutAuth_RedirectsToLoginUnderUrlBase()
+    {
+        _factory.SetConfigEnv();
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("http://localhost/torrentarr/"),
+            AllowAutoRedirect = false,
+        });
+        client.DefaultRequestHeaders.Accept.ParseAdd("text/html");
+
+        var response = await client.GetAsync("/web/token");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.ToString().Should().Be("/torrentarr/login");
     }
 }

--- a/tests/Torrentarr.Infrastructure.Tests/ApiClients/ArrClientResponseTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/ApiClients/ArrClientResponseTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using FluentAssertions;
+using RestSharp;
+using Torrentarr.Infrastructure.ApiClients.Arr;
+using Xunit;
+
+namespace Torrentarr.Infrastructure.Tests.ApiClients;
+
+public sealed class ArrClientResponseTests
+{
+    [Fact]
+    public void EnsureSuccess_ThrowsArrApiException_OnHttpFailure()
+    {
+        var response = new RestResponse
+        {
+            ResponseStatus = ResponseStatus.Completed,
+            StatusCode = HttpStatusCode.ServiceUnavailable,
+            StatusDescription = "Service Unavailable",
+            Content = null
+        };
+
+        var act = () => ArrClientResponse.EnsureSuccess(response, "GET /api/v3/movie");
+
+        act.Should().Throw<ArrApiException>()
+            .Which.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public void EnsureSuccess_DoesNotThrow_OnSuccess()
+    {
+        var response = new RestResponse
+        {
+            ResponseStatus = ResponseStatus.Completed,
+            StatusCode = HttpStatusCode.OK,
+            StatusDescription = "OK",
+            Content = "[]"
+        };
+
+        var act = () => ArrClientResponse.EnsureSuccess(response, "GET /api/v3/movie");
+
+        act.Should().NotThrow();
+    }
+}

--- a/tests/Torrentarr.Infrastructure.Tests/Services/ArrImportServiceTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/ArrImportServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Torrentarr.Core.Configuration;
 using Torrentarr.Infrastructure.Database;
+using Torrentarr.Infrastructure.Database.Models;
 using Torrentarr.Infrastructure.Services;
 using Xunit;
 
@@ -213,5 +214,47 @@ public class ArrImportServiceTests
             await svc.MarkAsImportedAsync("abc123", Enumerable.Empty<string>());
 
         await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task CustomFormatUnmetLookup_UsesArrIdNotSqliteEntryId()
+    {
+        var options = new DbContextOptionsBuilder<TorrentarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var db = new TorrentarrDbContext(options);
+
+        db.Movies.Add(new MoviesFilesModel
+        {
+            EntryId = 42,
+            Title = "Wrong Match",
+            ArrInstance = "Radarr-HD",
+            ArrId = 5,
+            MovieFileId = 999,
+            CustomFormatScore = 10
+        });
+        db.Movies.Add(new MoviesFilesModel
+        {
+            EntryId = 1,
+            Title = "Target Movie",
+            ArrInstance = "Radarr-HD",
+            ArrId = 42,
+            MovieFileId = 0,
+            CustomFormatScore = 50
+        });
+        await db.SaveChangesAsync();
+
+        const int queueMovieId = 42;
+
+        var correctLookup = await db.Movies.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.ArrId == queueMovieId && m.ArrInstance == "Radarr-HD");
+        correctLookup.Should().NotBeNull();
+        correctLookup!.Title.Should().Be("Target Movie");
+
+        var buggyLookup = await db.Movies.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.EntryId == queueMovieId && m.ArrInstance == "Radarr-HD");
+        buggyLookup.Should().NotBeNull();
+        buggyLookup!.Title.Should().Be("Wrong Match",
+            "EntryId collisions can make CustomFormatUnmet delete the wrong torrent");
     }
 }

--- a/tests/Torrentarr.Infrastructure.Tests/Services/ArrImportServiceTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/ArrImportServiceTests.cs
@@ -208,6 +208,30 @@ public class ArrImportServiceTests
         byEntryId.Should().BeNull("queue MovieId is the Arr API id, not the SQLite EntryId");
     }
 
+    [Fact]
+    public async Task CfUnmetSeriesLookup_RequiresMinCustomFormatScore_OnSeriesRow()
+    {
+        var options = new DbContextOptionsBuilder<TorrentarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var dbContext = new TorrentarrDbContext(options);
+        dbContext.Series.Add(new SeriesFilesModel
+        {
+            Title = "Test Series",
+            ArrInstance = "Sonarr-HD",
+            ArrId = 99,
+            MinCustomFormatScore = 200
+        });
+        await dbContext.SaveChangesAsync();
+
+        var seriesEntry = await dbContext.Series.AsNoTracking()
+            .FirstOrDefaultAsync(s => s.ArrId == 99 && s.ArrInstance == "Sonarr-HD");
+
+        seriesEntry.Should().NotBeNull();
+        seriesEntry!.MinCustomFormatScore.Should().Be(200,
+            "Sonarr series-search CF unmet checks MinCustomFormatScore on the series row");
+    }
+
     // ── MarkAsImportedAsync ───────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Torrentarr.Infrastructure.Tests/Services/ArrImportServiceTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/ArrImportServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Torrentarr.Core.Configuration;
 using Torrentarr.Infrastructure.Database;
+using Torrentarr.Infrastructure.Database.Models;
 using Torrentarr.Infrastructure.Services;
 using Xunit;
 
@@ -175,6 +176,36 @@ public class ArrImportServiceTests
         var act = async () => await svc.IsImportedAsync("abc123", cts.Token);
 
         await act.Should().NotThrowAsync();
+    }
+
+    // ── Custom format unmet DB lookup (regression: Arr API ids vs SQLite EntryId) ─
+
+    [Fact]
+    public async Task CfUnmetMovieLookup_MatchesArrId_NotEntryId()
+    {
+        var options = new DbContextOptionsBuilder<TorrentarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var dbContext = new TorrentarrDbContext(options);
+        dbContext.Movies.Add(new MoviesFilesModel
+        {
+            Title = "Test Movie",
+            ArrInstance = "Radarr-HD",
+            ArrId = 42,
+            MovieFileId = 1,
+            CustomFormatScore = 100,
+            MinCustomFormatScore = 200
+        });
+        await dbContext.SaveChangesAsync();
+
+        var byArrId = await dbContext.Movies.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.ArrId == 42 && m.ArrInstance == "Radarr-HD");
+        var byEntryId = await dbContext.Movies.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.EntryId == 42 && m.ArrInstance == "Radarr-HD");
+
+        byArrId.Should().NotBeNull();
+        byArrId!.Title.Should().Be("Test Movie");
+        byEntryId.Should().BeNull("queue MovieId is the Arr API id, not the SQLite EntryId");
     }
 
     // ── MarkAsImportedAsync ───────────────────────────────────────────────────

--- a/tests/Torrentarr.Infrastructure.Tests/Services/ArrSyncServiceTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/ArrSyncServiceTests.cs
@@ -172,6 +172,45 @@ public sealed class ArrSyncServiceTests : IDisposable
     }
 
     [Fact]
+    public void ShouldSkipDestructiveDelete_EmptyApiWithExistingRows_ReturnsTrue()
+    {
+        var svc = CreateService();
+        var method = typeof(ArrSyncService).GetMethod(
+            "ShouldSkipDestructiveDelete",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        var result = (bool)method.Invoke(svc, new object[] { 0, 5, "Lidarr-test", "tracks" })!;
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSkipDestructiveDelete_EmptyApiAndEmptyDb_ReturnsFalse()
+    {
+        var svc = CreateService();
+        var method = typeof(ArrSyncService).GetMethod(
+            "ShouldSkipDestructiveDelete",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        var result = (bool)method.Invoke(svc, new object[] { 0, 0, "Lidarr-test", "tracks" })!;
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSkipDestructiveDelete_NonEmptyApi_ReturnsFalse()
+    {
+        var svc = CreateService();
+        var method = typeof(ArrSyncService).GetMethod(
+            "ShouldSkipDestructiveDelete",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        var result = (bool)method.Invoke(svc, new object[] { 10, 5, "Radarr-test", "movies" })!;
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task SyncQueueAsync_UnknownArrType_DoesNotThrow()
     {
         // The switch has no default case for unknown types — falls through silently.

--- a/tests/Torrentarr.Infrastructure.Tests/Services/ArrSyncServiceTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/ArrSyncServiceTests.cs
@@ -210,6 +210,21 @@ public sealed class ArrSyncServiceTests : IDisposable
         result.Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData("artists")]
+    [InlineData("albums")]
+    public void ShouldSkipDestructiveDelete_LidarrEntities_EmptyApiWithExistingRows_ReturnsTrue(string entityName)
+    {
+        var svc = CreateService();
+        var method = typeof(ArrSyncService).GetMethod(
+            "ShouldSkipDestructiveDelete",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        var result = (bool)method.Invoke(svc, new object[] { 0, 12, "Lidarr-test", entityName })!;
+
+        result.Should().BeTrue();
+    }
+
     [Fact]
     public async Task SyncQueueAsync_UnknownArrType_DoesNotThrow()
     {

--- a/tests/Torrentarr.Infrastructure.Tests/Services/FreeSpaceServiceTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/FreeSpaceServiceTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Torrentarr.Core.Configuration;
 using Torrentarr.Core.Models;
 using Xunit;
 
@@ -54,25 +55,20 @@ public class FreeSpaceServiceTests
 
     // ── IsDownloadingState helper (replicated logic) ──────────────────────────
 
-    private static bool IsDownloadingState(string state)
-    {
-        return state.Contains("downloading", StringComparison.OrdinalIgnoreCase) ||
-               state.Contains("stalledDL", StringComparison.OrdinalIgnoreCase) ||
-               state.Contains("metaDL", StringComparison.OrdinalIgnoreCase);
-    }
-
     [Theory]
     [InlineData("downloading", true)]
     [InlineData("stalledDL", true)]
+    [InlineData("queuedDL", true)]
+    [InlineData("forcedDL", true)]
     [InlineData("metaDL", true)]
     [InlineData("Downloading", true)]   // case-insensitive
     [InlineData("uploading", false)]
     [InlineData("stalledUP", false)]
     [InlineData("pausedUP", false)]
     [InlineData("", false)]
-    public void IsDownloadingState_MatchesExpected(string state, bool expected)
+    public void IsActiveDownloadingStateForFreeSpace_MatchesExpected(string state, bool expected)
     {
-        IsDownloadingState(state).Should().Be(expected);
+        TorrentPolicyHelper.IsActiveDownloadingStateForFreeSpace(state).Should().Be(expected);
     }
 
     // ── HasTag helper (replicated logic from FreeSpaceService) ───────────────

--- a/tests/Torrentarr.Infrastructure.Tests/Services/SeedingServiceTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/SeedingServiceTests.cs
@@ -285,6 +285,52 @@ public class SeedingServiceTests
         result.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task HnrAllowsDeleteAsync_CategorySeedingHnr_BlocksWhenObligationsUnmet()
+    {
+        var config = new TorrentarrConfig();
+        config.QBitInstances["qBit"] = new QBitConfig
+        {
+            Trackers = new List<TrackerConfig>(),
+            CategorySeeding = new CategorySeedingConfig
+            {
+                HitAndRunMode = "and",
+                MinSeedRatio = 1.0,
+                MinSeedingTimeDays = 7
+            }
+        };
+        var svc = CreateService(config);
+        var torrent = MakeTorrent(1.0, 0.3, 1000);
+        torrent.QBitInstanceName = "qBit";
+
+        var result = await svc.HnrAllowsDeleteAsync(torrent, "removal criteria");
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HnrAllowsDeleteAsync_CategorySeedingHnr_AllowsWhenObligationsMet()
+    {
+        var config = new TorrentarrConfig();
+        config.QBitInstances["qBit"] = new QBitConfig
+        {
+            Trackers = new List<TrackerConfig>(),
+            CategorySeeding = new CategorySeedingConfig
+            {
+                HitAndRunMode = "or",
+                MinSeedRatio = 1.0,
+                MinSeedingTimeDays = 1
+            }
+        };
+        var svc = CreateService(config);
+        var torrent = MakeTorrent(1.0, 1.5, 1000);
+        torrent.QBitInstanceName = "qBit";
+
+        var result = await svc.HnrAllowsDeleteAsync(torrent, "removal criteria");
+
+        result.Should().BeTrue();
+    }
+
     // ── ShouldRemoveTorrentAsync state-based logic ───────────────────────────────
 
     [Fact]

--- a/tests/Torrentarr.Infrastructure.Tests/Services/TaglessTorrentLibraryHelperTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/TaglessTorrentLibraryHelperTests.cs
@@ -61,4 +61,23 @@ public class TaglessTorrentLibraryHelperTests
 
         (await db.TorrentLibrary.CountAsync()).Should().Be(0);
     }
+
+    [Fact]
+    public async Task SetFreeSpacePaused_ScopedPerQbitInstance()
+    {
+        await using var db = CreateDb();
+        db.TorrentLibrary.AddRange(
+            new() { Hash = "abc123", Category = "radarr", QbitInstance = "qBit", FreeSpacePaused = true },
+            new() { Hash = "abc123", Category = "radarr", QbitInstance = "qBit-seedbox", FreeSpacePaused = false });
+        await db.SaveChangesAsync();
+
+        await TaglessTorrentLibraryHelper.SetFreeSpacePausedAsync(
+            db, "abc123", "radarr", "qBit-seedbox", paused: true);
+
+        var entries = await db.TorrentLibrary.OrderBy(t => t.QbitInstance).ToListAsync();
+        entries[0].QbitInstance.Should().Be("qBit");
+        entries[0].FreeSpacePaused.Should().BeTrue();
+        entries[1].QbitInstance.Should().Be("qBit-seedbox");
+        entries[1].FreeSpacePaused.Should().BeTrue();
+    }
 }

--- a/tests/Torrentarr.Infrastructure.Tests/Services/TaglessTorrentLibraryHelperTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/TaglessTorrentLibraryHelperTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Torrentarr.Infrastructure.Database;
+using Torrentarr.Infrastructure.Services;
+using Xunit;
+
+namespace Torrentarr.Infrastructure.Tests.Services;
+
+public class TaglessTorrentLibraryHelperTests
+{
+    private static TorrentarrDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<TorrentarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new TorrentarrDbContext(options);
+    }
+
+    [Fact]
+    public async Task SetFreeSpacePaused_WhenRowMissing_InsertsRowWithFlagTrue()
+    {
+        await using var db = CreateDb();
+
+        await TaglessTorrentLibraryHelper.SetFreeSpacePausedAsync(
+            db, "abc123", "radarr", "qBit", paused: true);
+
+        var entry = await db.TorrentLibrary.SingleAsync();
+        entry.Hash.Should().Be("abc123");
+        entry.Category.Should().Be("radarr");
+        entry.QbitInstance.Should().Be("qBit");
+        entry.FreeSpacePaused.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SetFreeSpacePaused_WhenRowExists_UpdatesExistingRow()
+    {
+        await using var db = CreateDb();
+        db.TorrentLibrary.Add(new()
+        {
+            Hash = "abc123",
+            Category = "radarr",
+            QbitInstance = "qBit",
+            FreeSpacePaused = false
+        });
+        await db.SaveChangesAsync();
+
+        await TaglessTorrentLibraryHelper.SetFreeSpacePausedAsync(
+            db, "abc123", "radarr", "qBit", paused: true);
+
+        var entry = await db.TorrentLibrary.SingleAsync();
+        entry.FreeSpacePaused.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SetFreeSpacePaused_WhenRowMissingAndClearing_DoesNotInsert()
+    {
+        await using var db = CreateDb();
+
+        await TaglessTorrentLibraryHelper.SetFreeSpacePausedAsync(
+            db, "abc123", "radarr", "qBit", paused: false);
+
+        (await db.TorrentLibrary.CountAsync()).Should().Be(0);
+    }
+}

--- a/tests/Torrentarr.Infrastructure.Tests/Services/WebUIAuthHelpersTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/WebUIAuthHelpersTests.cs
@@ -61,11 +61,19 @@ public class WebUIAuthHelpersTests
     }
 
     [Fact]
-    public void IsSetPasswordAllowed_AllowsMatchingBearerToken()
+    public void IsSetPasswordAllowed_BearerApiToken_WhenPasswordUnset_AllowsBootstrap()
     {
-        var cfg = new TorrentarrConfig { WebUI = new WebUIConfig { Token = "api-token" } };
-        WebUIAuthHelpers.IsSetPasswordAllowed(cfg, null, isAuthenticated: false, bearerOrQueryToken: "api-token")
+        var cfg = new TorrentarrConfig { WebUI = { Token = "api-token", PasswordHash = "" } };
+        WebUIAuthHelpers.IsSetPasswordAllowed(cfg, setupToken: null, isAuthenticated: false, bearerOrQueryToken: "api-token")
             .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSetPasswordAllowed_BearerApiToken_WhenPasswordAlreadySet_DeniesReset()
+    {
+        var cfg = new TorrentarrConfig { WebUI = { Token = "api-token", PasswordHash = "hashed" } };
+        WebUIAuthHelpers.IsSetPasswordAllowed(cfg, setupToken: null, isAuthenticated: false, bearerOrQueryToken: "api-token")
+            .Should().BeFalse();
     }
 
     [Fact]

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -39,7 +39,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.6",
         "autoprefixer": "^10.5.0",
-        "eslint": "^10.3.0",
+        "eslint": "^10.4.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3093,18 +3093,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",

--- a/webui/package.json
+++ b/webui/package.json
@@ -31,7 +31,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.6",
     "autoprefixer": "^10.5.0",
-    "eslint": "^10.3.0",
+    "eslint": "^10.4.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -45,6 +45,7 @@ import {
   AuthError,
 } from "./api/client";
 import type { MetaResponse } from "./api/types";
+import { isLoginPathname, webPath } from "./api/urlBase";
 import { IconImage } from "./components/IconImage";
 import CloseIcon from "./icons/close.svg";
 import ExternalIcon from "./icons/github.svg";
@@ -603,7 +604,7 @@ function LoginRoute(): JSX.Element {
       .then((m) => {
         if (cancelled) return;
         setMeta(m);
-        if (!m.auth_required) window.location.replace("/ui");
+        if (!m.auth_required) window.location.replace(webPath("/ui"));
       })
       .catch(() => {
         if (!cancelled) setMeta({} as MetaResponse);
@@ -619,7 +620,7 @@ function LoginRoute(): JSX.Element {
       localAuthEnabled={meta.local_auth_enabled ?? true}
       oidcEnabled={meta.oidc_enabled ?? false}
       showSetupFirst={meta.setup_required ?? false}
-      onSuccess={() => window.location.replace("/ui")}
+      onSuccess={() => window.location.replace(webPath("/ui"))}
     />
   );
 }
@@ -1447,8 +1448,7 @@ function AppShell(): JSX.Element {
 }
 
 export default function App(): JSX.Element {
-  const pathname = window.location.pathname;
-  const isLoginPath = pathname === "/login" || pathname === "/login/";
+  const isLoginPath = isLoginPathname(window.location.pathname);
 
   return (
     <ToastProvider>

--- a/webui/src/__tests__/api/urlBase.test.ts
+++ b/webui/src/__tests__/api/urlBase.test.ts
@@ -26,6 +26,26 @@ describe("urlBase", () => {
     expect(pathnameUrlBase()).toBe("");
   });
 
+  it("pathnameUrlBase extracts prefix from /ui and /login under UrlBase", async () => {
+    stubLocation("/torrentarr/ui");
+    const { pathnameUrlBase } = await loadUrlBase();
+    expect(pathnameUrlBase()).toBe("/torrentarr");
+  });
+
+  it("pathnameUrlBase extracts prefix from nested login path", async () => {
+    stubLocation("/torrentarr/login/");
+    const { pathnameUrlBase } = await loadUrlBase();
+    expect(pathnameUrlBase()).toBe("/torrentarr");
+  });
+
+  it("isLoginPathname matches login routes with UrlBase", async () => {
+    stubLocation("/torrentarr/login");
+    const { isLoginPathname } = await loadUrlBase();
+    expect(isLoginPathname("/torrentarr/login")).toBe(true);
+    expect(isLoginPathname("/torrentarr/ui")).toBe(false);
+    expect(isLoginPathname("/login")).toBe(true);
+  });
+
   it("getUrlBase prefers meta cache over pathname", async () => {
     stubLocation("/qbitrr/static/index.html");
     const { getUrlBase, setUrlBaseFromMeta } = await loadUrlBase();

--- a/webui/src/__tests__/config/durationUtils.test.ts
+++ b/webui/src/__tests__/config/durationUtils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { durationDisplayToValue } from "../../config/durationUtils";
+
+describe("durationDisplayToValue", () => {
+  it("returns base-unit seconds for hour selections", () => {
+    expect(durationDisplayToValue(2, "h", "seconds", false)).toBe(7200);
+  });
+
+  it("returns base-unit minutes for day selections", () => {
+    expect(durationDisplayToValue(1, "d", "minutes", false)).toBe(1440);
+  });
+
+  it("preserves -1 sentinel values", () => {
+    expect(durationDisplayToValue(-1, "h", "seconds", true)).toBe(-1);
+  });
+});

--- a/webui/src/api/urlBase.ts
+++ b/webui/src/api/urlBase.ts
@@ -3,8 +3,7 @@ let cachedUrlBaseFromMeta: string | null = null;
 
 /** Derive UrlBase from the current page pathname before /web/meta is loaded. */
 export function pathnameUrlBase(): string {
-  const path =
-    window.location.pathname.replace(/\/$/, "") || "/";
+  const path = window.location.pathname.replace(/\/$/, "") || "/";
 
   const staticMatch = path.match(/^(.*)\/static\/index\.html$/);
   if (staticMatch) return staticMatch[1];

--- a/webui/src/api/urlBase.ts
+++ b/webui/src/api/urlBase.ts
@@ -1,12 +1,21 @@
 /** Public URL path prefix when the WebUI is served under a subpath (e.g. /qbitrr). */
 let cachedUrlBaseFromMeta: string | null = null;
 
-/** Derive UrlBase from the current page pathname (e.g. /qbitrr/static/index.html). */
+/** Derive UrlBase from the current page pathname before /web/meta is loaded. */
 export function pathnameUrlBase(): string {
-  const staticMatch = window.location.pathname.match(
-    /^(.*)\/static\/index\.html$/,
-  );
-  return staticMatch ? staticMatch[1] : "";
+  const path =
+    window.location.pathname.replace(/\/$/, "") || "/";
+
+  const staticMatch = path.match(/^(.*)\/static\/index\.html$/);
+  if (staticMatch) return staticMatch[1];
+
+  const uiOrLoginMatch = path.match(/^(.*)\/(?:ui|login)$/);
+  if (uiOrLoginMatch) return uiOrLoginMatch[1];
+
+  const webMatch = path.match(/^(.*)\/web(?:\/|$)/);
+  if (webMatch) return webMatch[1];
+
+  return "";
 }
 
 /** Return the active UrlBase prefix (pathname first, then meta after load). */
@@ -27,6 +36,14 @@ export function setUrlBaseFromMeta(base: string | undefined): void {
 /** Clear cached UrlBase (for Vitest isolation). */
 export function resetUrlBaseCacheForTests(): void {
   cachedUrlBaseFromMeta = null;
+}
+
+/** True when the current pathname is the login route (with or without UrlBase). */
+export function isLoginPathname(pathname: string): boolean {
+  const normalized = pathname.replace(/\/$/, "") || "/";
+  if (normalized === "/login") return true;
+  const base = getUrlBase();
+  return base !== "" && normalized === `${base}/login`;
 }
 
 /** Prefix an app-relative path (must start with /) with the active UrlBase. */

--- a/webui/src/config/durationUtils.ts
+++ b/webui/src/config/durationUtils.ts
@@ -141,9 +141,8 @@ export function durationDisplayToValue(
   unit: DurationUnit,
   baseUnit: "seconds" | "minutes",
   allowNegative: boolean,
-): string | number {
+): number {
   if (allowNegative && number === -1) return -1;
   const total = numberAndUnitToTotal(number, unit, baseUnit);
-  const out = toSuffixed(total, baseUnit);
-  return typeof out === "number" ? out : out;
+  return baseUnit === "minutes" ? Math.floor(total) : Math.round(total);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates the focused fixes recommended by the [PR triage audit](docs/audits/pr-triage-2026-06-11.md) into a single mergeable branch. Supersedes overlapping draft PRs #206–#217 (except dependabot #127).

### Fixes included

| Source | Fix |
|--------|-----|
| #217 | HnR protection in `RemoveCompletedTorrentsAsync` |
| #206 | CF-unmet queue lookups use `ArrId` not `EntryId` |
| #213 | Arr API clients throw on HTTP failure (no silent `[]`) |
| #215 | `ShouldSkipDestructiveDelete` guard + WebUI duration save |
| #216 | qBit tracker TOML serialization + qB v5 free-space states |
| #197 | Tagless free-space: `QBitInstance` scoping + TorrentLibrary upsert |
| #212 | POST `/api/config` dotted merge + qBit download path for free-space |
| #171 | Block bearer `WebUI.Token` set-password when password already set |
| #172 | UrlBase login redirects and SPA path resolution |

### Merge conflict resolutions

- **#197 + master:** Combined `instanceName` tracking with queue-position sort from `TorrentPolicyHelper`.
- **#212 + #216:** Unified config save via `ApplyDottedConfigChanges` + `SaveAndRespondConfigUpdate` with validation.

## Testing

- `dotnet test --filter "Category!=Live"` — **719 passed** (159 Core + 370 Infrastructure + 190 Host)
- `npx vitest run src/__tests__/config/durationUtils.test.ts` — **3 passed**

## Follow-up

After merge, close duplicate draft PRs: #173, #187, #192, #194, #195, #200, #203, #206, #211, #213, #214, #215, #216, #217, #171, #172 (superseded by this branch).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abdd4aa0-95cf-4447-851b-72be2a2e5c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abdd4aa0-95cf-4447-851b-72be2a2e5c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

