### PR TITLE
build(deps): bump Serilog.AspNetCore to 10.0.0

### DIFF
--- a/src/Torrentarr.Core/Torrentarr.Core.csproj
+++ b/src/Torrentarr.Core/Torrentarr.Core.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Tomlyn" Version="0.17.0" />
-    <PackageReference Include="Serilog" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />

--- a/src/Torrentarr.Host/Torrentarr.Host.csproj
+++ b/src/Torrentarr.Host/Torrentarr.Host.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Torrentarr.Infrastructure/Torrentarr.Infrastructure.csproj
+++ b/src/Torrentarr.Infrastructure/Torrentarr.Infrastructure.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="FFMpegCore" Version="5.4.0" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Torrentarr.WebUI/Torrentarr.WebUI.csproj
+++ b/src/Torrentarr.WebUI/Torrentarr.WebUI.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.8" />
   </ItemGroup>
 

--- a/src/Torrentarr.Workers/Torrentarr.Workers.csproj
+++ b/src/Torrentarr.Workers/Torrentarr.Workers.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebases and supersedes dependabot #127 with a clean bump onto current master.

- **Host/WebUI:** `Serilog.AspNetCore` 8.0.3 → 10.0.0 (.NET 10 alignment)
- **Workers:** `Serilog.Extensions.Hosting` 8.0.0 → 10.0.0
- **Core/Infrastructure:** `Serilog` → 4.3.0 for consistency

## Validation

- `dotnet build -c Release` — pass
- `dotnet test --filter "Category!=Live"` — 738 tests pass
- `LogLevelEndpointTests` — 12/12 pass

## Notes

Torrentarr uses standard Serilog APIs only (`LoggerConfiguration`, `UseSerilog`, `LoggingLevelSwitch`, custom `ILogEventSink`). No code changes required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abdd4aa0-95cf-4447-851b-72be2a2e5c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abdd4aa0-95cf-4447-851b-72be2a2e5c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

