### PR TITLE
docs: one-shot PR triage audit report (27 open PRs)

### DIFF
--- a/docs/audits/pr-triage-2026-06-15.md
+++ b/docs/audits/pr-triage-2026-06-15.md
@@ -1,0 +1,203 @@
+# PR Triage Report — 2026-06-15
+
+Audit of **27 open pull requests** on `feramance/torrentarr`. Validated against `master` at `70598c0`, qBitrr 5.12.3 parity intent, local `dotnet test --filter "Category!=Live"` (738 pass), `npx vitest run` (154 pass), and PR metadata.
+
+Prior report [`pr-triage-2026-06-11.md`](pr-triage-2026-06-11.md) is **stale** — many June 11 PRs (#171–#217) were merged or closed; master gained #228 (episode guard, tagless free-space), #230 (Serilog 10.x), and Arr-sync guards.
+
+---
+
+## Executive summary
+
+| Verdict | Count | PRs |
+|---------|-------|-----|
+| **Implement** | **4** | #229, #271, #258, #243 |
+| **Cherry-pick** | **2 themes** | CF-unmet HnR from #255; config instance preservation from #255 |
+| **Close (duplicate)** | **17** | #188, #197, #247, #248, #250, #251, #253, #254, #256, #260, #265, #266, #267, #268, #270, #127, #258† |
+| **Defer** | **5** | #234, #238, #239, #264, #269 |
+| **Partial (optional)** | **1** | #231 — qB v5 import readiness after tagless merge |
+
+† #258 is listed in Implement for `/api/config` dotted-only; close only if #271+#258 merge as one security batch — prefer merging #258 for API path fix after #271.
+
+**Recommended merge order:**
+
+1. **#229** — Tagless `(Hash, QbitInstance)` scoping in `FreeSpaceService`, `SeedingService`, `TorrentProcessor` (10 files, +6 tests)
+2. **#271** — Block `WebUI.PasswordHash` writes via config API (`RejectPasswordHashConfigChange`, 403)
+3. **#258** — Require `changes` object on `POST /api/config` (no full JSON replace)
+4. **#243** — Lidarr track sync guard when albums API empty but tracks API returns data
+5. **Cherry-pick** CF-unmet `HnrAllowsDeleteAsync` from **#255** (`TorrentProcessor.cs` ~15 lines) onto a new branch
+6. **Defer** Dependabot bumps until critical fixes land; auto-merge patch minors when CI green
+
+---
+
+## Confirmed bugs on master (`70598c0`)
+
+| # | Bug | Status | Evidence |
+|---|-----|--------|----------|
+| 1 | Arr sync mass-delete on API failure | **Fixed** | `ShouldSkipDestructiveDelete` in `ArrSyncService.cs` (movies, series, episodes, artists, albums, tracks ~884) |
+| 2 | Sonarr episode wipe on empty API | **Fixed** | Episode guard ~388–389 (`#228`) |
+| 3 | Lidarr track wipe when albums empty | **Partial** | Basic empty-API guard ~884; edge case when albums guarded but tracks mappable count is 0 still risky — **#243** fixes |
+| 4 | HnR bypass in removal loop | **Fixed** | `HnrAllowsDeleteAsync` before delete ~702 in `SeedingService.cs` |
+| 5 | HnR bypass on CF-unmet delete | **Open** | `TorrentProcessor.cs` ~343–353 deletes without `HnrAllowsDeleteAsync` |
+| 6 | Bearer set-password bypass | **Fixed** | `WebUIAuthHelpers.cs` ~60–64 `PasswordHash` gate |
+| 7 | Setup-token password reset when hash set | **Fixed** | `WebUIAuthHelpers.cs` ~74–78 bootstrap-only `WebUI.Token` |
+| 8 | Tagless `HasTag` / `AllowedSeeding` instance bleed | **Open** | Hash-only: `FreeSpaceService.cs` ~447, `SeedingService.cs` ~854–891 |
+| 9 | Tagless free-space upsert | **Fixed** | `TaglessTorrentLibraryHelper.cs` + `FreeSpaceService.SetFreeSpacePausedTagAsync` |
+| 10 | Config `PasswordHash` via dotted API | **Open** | `ApplyDottedConfigChanges` blocks `[redacted]` only ~2643–2646 |
+| 11 | `POST /api/config` full JSON replace | **Open** | Deserialize fallback ~2161–2164 in `Program.cs` |
+| 12 | Config partial save drops placeholder qBit sections | **Open** | `ApplyDottedConfigChanges` filters `Host != "CHANGE_ME"` ~2633 |
+| 13 | Duration save corruption | **Fixed** | `durationUtils.ts` returns numeric totals |
+| 14 | Tracker TOML wipe on save | **Fixed** | `AppendTrackersSection` in `ConfigurationLoader.cs` ~1912 |
+| 15 | CF-unmet wrong queue ID | **Fixed** | `ArrImportService.cs` uses `ArrId` ~356+ |
+| 16 | Dependabot #127 Serilog 10.x | **Stale** | Merged via **#230** |
+
+---
+
+## Implement (approved)
+
+| PR | Theme | Files | Why | Tests (local) |
+|----|-------|-------|-----|---------------|
+| **#229** | Tagless instance scoping | 10 | Fixes `HasTag` + `AllowedSeeding` `ExecuteUpdate` + `TorrentProcessor.HasTag` with `(Hash, QbitInstance)`; adds `TaglessInstanceScopeTests` | **744** pass (167+191+386) |
+| **#271** | Config PasswordHash security | 5 | `RejectPasswordHashConfigChange` returns 403 for direct hash writes/clears; Host + WebUI paths; 67 lines of config tests | **745** pass (167+194+384) |
+| **#258** | `/api/config` dotted-only | 9 | Removes full JSON deserialize on `/api/config`; skips `WebUI.PasswordHash` in merge; partial tagless (subset of #229) | **741** pass (167+194+380) |
+| **#243** | Lidarr track sync edge case | 4 | `ShouldSkipDestructiveTrackSync` when tracks unmappable to albums after albums API guard | **741** pass (167+191+383) |
+
+---
+
+## Cherry-pick / Partial
+
+| Source | Keep | Discard | Why |
+|--------|------|---------|-----|
+| **#255** | `TorrentProcessor` CF-unmet `HnrAllowsDeleteAsync` (~15 lines) | Full PR — 7 Infra test failures on isolated run (ConfigReloader/ArrThumbnail env pollution suspected; re-verify) | Surgical HnR fix still needed on master |
+| **#255** | `ApplyDottedConfigChanges` preserve `QBitInstances`/`ArrInstances` dict + no `CHANGE_ME` filter | Arr client throw hunks if already on master | Config wipe on partial save |
+| **#231** | qB v5 `stalledUP` seeding + import grace `pausedUP` | Merge as whole only after #229 — overlaps tagless SeedingService lines | Small, test-covered v5 parity slice |
+
+---
+
+## Close (duplicate)
+
+| PR | Superseded by | Why |
+|----|---------------|-----|
+| **#127** | #230 | Serilog 10.x already merged |
+| **#188** | #229 | Older base; tagless scoping + lockfile noise; 6 conflict hints |
+| **#197** | master + #229 | `TaglessTorrentLibraryHelper` already on master (#228); upsert redundant |
+| **#247** | #229 | Same tagless theme + lockfile churn |
+| **#248** | #229 + #271 | Kitchen-sink duplicate |
+| **#250** | #229 | Tagless lookup duplicate |
+| **#251** | #229 + #271 + #243 | Multi-theme duplicate |
+| **#253** | #229 + #255 cherry-pick | Tagless + HnR duplicate |
+| **#254** | #229 + #243 + #255 | Multi-theme duplicate |
+| **#255** | #229 + #271 + #258 + cherry-picks | Tests failed locally; split into focused merges |
+| **#256** | #229 + #271 + #243 | Multi-theme duplicate |
+| **#260** | #229 + #271 + #243 | Multi-theme duplicate |
+| **#265** | #243 + #229 | Lidarr + tagless duplicate |
+| **#266** | #229 + #271 | Multi-theme duplicate |
+| **#267** | #229 + #271 + #243 | Multi-theme duplicate |
+| **#268** | #229 | Tagless duplicate |
+| **#270** | #229 + #271 + #243 | Multi-theme duplicate |
+
+---
+
+## Defer
+
+| PR | Reason |
+|----|--------|
+| **#234** | vitest coverage-v8 patch — merge after critical fixes |
+| **#238** | tailwindcss postcss patch |
+| **#239** | react-hook-form patch |
+| **#264** | Microsoft.Extensions.Http / Logging.Abstractions |
+| **#269** | Microsoft.Extensions.Logging.Abstractions |
+
+---
+
+## Consolidation plan
+
+### Phase A — Merge winners (maintainer)
+
+```bash
+gh pr ready 229 271 258 243   # drafts → ready for CI matrix
+# Merge in order: 229 → 271 → 258 → 243
+# Rebase each subsequent PR onto master after prior merge
+```
+
+### Phase B — Cherry-pick HnR CF-unmet
+
+```bash
+git checkout -b cursor/cf-unmet-hnr-guard-e585 master
+# Apply TorrentProcessor.cs hunk from PR #255
+dotnet test --filter "Category!=Live"
+```
+
+### Phase C — Close duplicates
+
+Close with link to this report: #127, #188, #197, #247–#251, #253, #254, #256, #260, #265–#268, #270, #255.
+
+### Phase D — Enable Cursor Automation
+
+See [`pr-triage-automation.md`](pr-triage-automation.md) — create at [cursor.com/automations](https://cursor.com/automations) after this report is approved.
+
+---
+
+## Test results summary
+
+| Branch / PR | `dotnet test Category!=Live` | `vitest run` | Notes |
+|-------------|------------------------------|--------------|-------|
+| `master` (`70598c0`) | **738** (167+191+380) | **154** | Baseline |
+| #229 | **744** (167+191+386) | — | +6 Infra tests |
+| #271 | **745** (167+194+384) | — | +3 Host tests |
+| #258 | **741** (167+194+380) | — | Clean |
+| #243 | **741** (167+191+383) | — | +3 Infra tests |
+| #255 | **733** (168+192+374) | — | **7 Infra failures** — ConfigReloader/ArrThumbnail (investigate before merge) |
+
+Draft PRs skip full CI `build` matrix on GitHub; local runs were required.
+
+---
+
+## Per-PR appendix (five-axis scores)
+
+Legend: Bug validity / Fix correctness / Tests / Hygiene / Overlap — **P**ass **F**ail **N**/A
+
+| PR | Title (short) | B | F | T | H | O | Verdict |
+|----|---------------|---|---|---|---|---|---------|
+| 271 | PasswordHash config block | P | P | P | P | P | **Implement** |
+| 258 | api/config dotted + hash skip | P | P | P | P | F | **Implement** |
+| 243 | Lidarr track wipe guard | P | P | P | P | F | **Implement** |
+| 229 | Tagless instance scoping | P | P | P | P | P | **Implement** |
+| 231 | v5 import + tagless worker | P | P | P | P | F | **Partial** |
+| 255 | HnR + config + sync | P | P | F | P | F | **Cherry-pick** |
+| 254 | Lidarr + tagless + HnR | P | P | P | F | F | **Close** |
+| 256 | Multi critical | P | P | P | F | F | **Close** |
+| 251 | Auth + Lidarr + tagless | P | P | P | P | F | **Close** |
+| 248 | Auth + tagless | P | P | P | P | F | **Close** |
+| 247 | Tagless worker DB | P | P | P | F | F | **Close** |
+| 253 | Tagless + HnR | P | P | P | P | F | **Close** |
+| 260 | Lidarr + auth + tagless | P | P | P | P | F | **Close** |
+| 265 | Lidarr + tagless | P | P | P | P | F | **Close** |
+| 266 | Tagless + auth + Arr | P | P | P | P | F | **Close** |
+| 267 | Lidarr + security + tagless | P | P | P | P | F | **Close** |
+| 268 | Tagless reads/writes | P | P | P | P | F | **Close** |
+| 270 | Lidarr + auth + tagless | P | P | P | P | F | **Close** |
+| 250 | Tagless lookups | P | P | P | P | F | **Close** |
+| 197 | Tagless upsert | N | N | P | P | F | **Close** (on master) |
+| 188 | Tagless scoping | P | P | P | F | F | **Close** |
+| 127 | Serilog 8→10 | N | N | N | P | F | **Close** (superseded) |
+| 234 | vitest coverage | N | P | N | P | P | **Defer** |
+| 238 | tailwind postcss | N | P | N | P | P | **Defer** |
+| 239 | react-hook-form | N | P | N | P | P | **Defer** |
+| 264 | Extensions.Http | N | P | N | P | P | **Defer** |
+| 269 | Logging.Abstractions | N | P | N | P | P | **Defer** |
+
+---
+
+## Hygiene highlights
+
+| PR | Files | `.cs`/`.ts` | Issue |
+|----|-------|-------------|-------|
+| #229 | 10 | 10 | Exemplary focused fix |
+| #271 | 5 | 5 | Exemplary security fix |
+| #188 | 7 | 5 | 37% lockfile noise |
+| #255 | 12 | 10 | Multi-theme; test failures |
+| #127 | 2 | 0 | Stale Dependabot |
+
+---
+
+*Generated by PR Audit Agent — 2026-06-15. Master commit: `70598c0`.*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

One-shot audit of all **27 open pull requests** on Torrentarr, validated against `master` at `70598c0`.

Adds [`docs/audits/pr-triage-2026-06-15.md`](docs/audits/pr-triage-2026-06-15.md) with:

- Confirmed bugs still on master (16 themes re-baselined post-#228/#230)
- Verdicts for every open PR (Implement / Close / Defer / Cherry-pick)
- Recommended merge order: **#229 → #271 → #258 → #243**, then cherry-pick CF-unmet HnR from #255
- Local test evidence for finalist branches (738 tests on master; up to 745 on finalists)
- Five-axis score appendix for all 27 PRs

## Key recommendations

| Action | PRs |
|--------|-----|
| **Merge** | #229, #271, #258, #243 |
| **Close as duplicate** | #127, #188, #197, #247–#251, #253, #254, #256, #260, #265–#268, #270, #255 |
| **Defer** | Dependabot #234, #238, #239, #264, #269 |

## Next step

After this report is approved, enable the Cursor Automation spec in a follow-up PR (`docs/audits/pr-triage-automation.md`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a0a5708-b6a9-42d8-8c3f-1ad8e0a9e585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a0a5708-b6a9-42d8-8c3f-1ad8e0a9e585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

