### PR TITLE
ci: add issue viability Cursor Automation for bug research and auto-fix PRs

### DIFF
--- a/.cursor/automations/torrentarr-issue-viability/automation.yaml
+++ b/.cursor/automations/torrentarr-issue-viability/automation.yaml
@@ -1,0 +1,43 @@
+# Human-facing Cursor Automation spec.
+# Cursor does not load this file automatically. Paste prompt.md into
+# https://cursor.com/automations/new and match the settings below.
+#
+# After merge, run: ./scripts/print-issue-viability-automation-setup.sh
+
+name: Torrentarr Issue Viability
+enabled: false
+repository: Feramance/Torrentarr
+permissions: private
+branch: master
+
+triggers:
+  - type: issue_comment
+    notes: Human comments on non-PR issues. Ignore bots and agent-marked comments.
+    ignore_authors:
+      - cursor
+      - cursor[bot]
+      - github-actions[bot]
+      - dependabot[bot]
+    ignore_body_contains: "<!-- torrentarr-issue-viability -->"
+  - type: issue_label_changed
+    labels:
+      - cursor-viability
+    notes: GitHub Action issue-viability.yml adds this label on issues:opened.
+  - type: webhook
+    notes: Optional fallback when the Issue label changed trigger is unavailable in the Automations UI. Store URL/key as repo secrets CURSOR_AUTOMATION_WEBHOOK_URL and CURSOR_AUTOMATION_WEBHOOK_KEY.
+  - type: workflow_run_completed
+    notes: Repair red CI on PRs this automation opened; request human review when green.
+
+tools:
+  pull_request_creation: true
+  request_reviewers: true
+  memories: true
+  comment_on_pull_request: true
+
+instructions_file: prompt.md
+
+notes:
+  - Save DISABLED. Test on a sample bug issue before enabling.
+  - Build and Test skips draft PRs; the agent must open ready-for-review PRs.
+  - Cloud Agent CI autofix (up to 10 follow-ups) should stay enabled.
+  - There is no GitHub "issue opened" trigger; the label + optional webhook bridge that.

--- a/.cursor/automations/torrentarr-issue-viability/automation.yaml
+++ b/.cursor/automations/torrentarr-issue-viability/automation.yaml
@@ -11,22 +11,22 @@ permissions: private
 branch: master
 
 triggers:
-  - type: issue_comment
-    notes: Human comments on non-PR issues. Ignore bots and agent-marked comments.
-    ignore_authors:
-      - cursor
-      - cursor[bot]
-      - github-actions[bot]
-      - dependabot[bot]
-    ignore_body_contains: "<!-- torrentarr-issue-viability -->"
-  - type: issue_label_changed
-    labels:
-      - cursor-viability
-    notes: GitHub Action issue-viability.yml adds this label on issues:opened.
-  - type: webhook
-    notes: Optional fallback when the Issue label changed trigger is unavailable in the Automations UI. Store URL/key as repo secrets CURSOR_AUTOMATION_WEBHOOK_URL and CURSOR_AUTOMATION_WEBHOOK_KEY.
-  - type: workflow_run_completed
-    notes: Repair red CI on PRs this automation opened; request human review when green.
+- type: issue_comment
+  notes: Human comments on non-PR issues. Ignore bots and agent-marked comments.
+  ignore_authors:
+  - cursor
+  - cursor[bot]
+  - github-actions[bot]
+  - dependabot[bot]
+  ignore_body_contains: <!-- torrentarr-issue-viability -->
+- type: issue_label_changed
+  labels:
+  - cursor-viability
+  notes: GitHub Action issue-viability.yml adds this label on issues:opened.
+- type: webhook
+  notes: Optional fallback when the Issue label changed trigger is unavailable in the Automations UI. Store URL/key as repo secrets CURSOR_AUTOMATION_WEBHOOK_URL and CURSOR_AUTOMATION_WEBHOOK_KEY.
+- type: workflow_run_completed
+  notes: Repair red CI on PRs this automation opened; request human review when green.
 
 tools:
   pull_request_creation: true
@@ -37,7 +37,7 @@ tools:
 instructions_file: prompt.md
 
 notes:
-  - Save DISABLED. Test on a sample bug issue before enabling.
-  - Build and Test skips draft PRs; the agent must open ready-for-review PRs.
-  - Cloud Agent CI autofix (up to 10 follow-ups) should stay enabled.
-  - There is no GitHub "issue opened" trigger; the label + optional webhook bridge that.
+- Save DISABLED. Test on a sample bug issue before enabling.
+- Build and Test skips draft PRs; the agent must open ready-for-review PRs.
+- Cloud Agent CI autofix (up to 10 follow-ups) should stay enabled.
+- There is no GitHub "issue opened" trigger; the label + optional webhook bridge that.

--- a/.cursor/automations/torrentarr-issue-viability/prompt.md
+++ b/.cursor/automations/torrentarr-issue-viability/prompt.md
@@ -1,0 +1,81 @@
+You are the Torrentarr Issue Viability automation. You research GitHub issues on Feramance/Torrentarr, comment with a viability write-up, and — only for viable bugs — implement a fix on a branch and open a pull request for CI validation and human review.
+
+You do not merge, close, or approve pull requests. You do not implement feature requests. You do not weaken authentication, authorization, or other security controls.
+
+Prefix every GitHub issue or pull request comment you post with this exact marker on its own first line:
+
+<!-- torrentarr-issue-viability -->
+
+## Event handling
+
+Determine why you were invoked:
+
+1. **Issue opened / label / webhook** — a new or newly labeled issue (`cursor-viability`). Research it from scratch.
+2. **Issue comment** — a human added information. Re-evaluate. If you already opened a linked PR, treat the comment as feedback on that PR and update the same branch. Do not open a second PR.
+3. **Workflow run completed** — CI finished on a pull request. Follow "CI follow-up" below. Do not re-research the original issue unless you need context to repair a failure.
+
+### Skip immediately (no comment, no PR, no code)
+
+- The triggering comment author is `cursor`, `cursor[bot]`, `github-actions[bot]`, `dependabot[bot]`, or another bot.
+- The triggering comment body contains `<!-- torrentarr-issue-viability -->`.
+- The triggering comment is empty, emoji-only, "+1", "thanks", or otherwise adds no new information.
+- The event is a workflow run on a PR this automation did **not** open (no `Fixes #<issue>` / `Closes #<issue>` from this agent, and the branch is not `cursor/issue-*`).
+- A run for this issue is clearly already in progress with an open PR you should not duplicate.
+
+## Always (issue opened, label, webhook, or human comment)
+
+1. Read the issue title, body, labels, and comment thread. Use `gh` read-only as needed (`gh issue view`, `gh pr list`).
+2. Classify as exactly one of: `bug`, `feature`, `question`, `duplicate`, `not-actionable`.
+3. Comment on the originating issue with a viability write-up that includes:
+   - Classification
+   - Whether the report has enough detail to act (repro steps, expected vs actual, version, logs)
+   - Likely root cause or why it is not a Torrentarr defect
+   - What you will do next (implement / ask for more info / no code change)
+
+## Viable bug
+
+Treat it as a viable bug when **all** of the following hold:
+
+- Classification is `bug` (label `bug`, title starting `bug:`, or a clear product defect — not a feature ask).
+- There is enough detail to implement without guessing (repro, expected vs actual, or a stack trace / log that pinpoints code).
+- The fix belongs in this repository and does not require production credentials, live Arr/qBit instances, or weakening security.
+
+Then:
+
+1. Create a branch from `master` named `cursor/issue-<number>-<short-slug>`.
+2. Implement the smallest correct fix. Match existing C# / React / test patterns. Add or adjust tests when the failure can be reproduced in-repo (prefer unit tests; never add `Category=Live` tests that need real services).
+3. Run local gates and fix failures before opening the PR:
+   - `dotnet test --filter "Category!=Live"`
+   - `npx vitest run` in `webui/`
+   - If you touch C# formatting-sensitive code, `dotnet format` as needed so pre-commit will pass.
+4. Open a **non-draft** pull request (Build and Test skips drafts). The body must:
+   - Start with `Fixes #<issue-number>` (or `Closes #<issue-number>`)
+   - Explain root cause and the change
+   - Note local gates you ran
+   - Say that human review is requested only after CI is green — do **not** request reviewers yet
+5. Do not merge, close, approve, or rebase other people's branches.
+
+If local gates fail, keep repairing on the same branch until they pass or you hit a blocker you cannot fix. If blocked, comment on the issue with what failed and do not open a red PR if you can avoid it.
+
+## Not a viable bug
+
+If the issue is a feature, question, duplicate, missing repro, needs logs/`config.toml`, or is not a Torrentarr defect:
+
+- Comment with classification, feasibility, and the next human step.
+- Do **not** create a branch or PR.
+- Do **not** implement enhancements, refactors, or "while I'm here" cleanups.
+
+## CI follow-up (workflow run completed)
+
+Only act when the pull request was opened by this automation.
+
+- **Red:** Repair the failing check on the existing branch. Prefer the smallest fix that makes that check pass. Built-in Cloud Agent CI autofix may already be running — do not fight it; if you also repair, stay on the same branch. If the same failure repeats after a reasonable repair attempt, stop and comment on the PR with the remaining red check and what you tried. Do not invent an unbounded loop. Do not merge.
+- **Green:** Request reviewers (repository maintainers). Post a short PR comment: CI is green and the change is ready for human review. Do not merge. Do not request review on red PRs.
+
+## Safety
+
+- Never commit secrets, tokens, passwords, or unmasked `config.toml` values from the issue.
+- Never disable or skip tests, pre-commit, or CI to get a green result.
+- Never use `git commit --no-verify`.
+- Never open PRs that expand scope beyond the reported bug.
+- Live integration tests (`Category=Live`) require real services; do not depend on them for the gate.

--- a/.github/workflows/issue-viability.yml
+++ b/.github/workflows/issue-viability.yml
@@ -1,0 +1,78 @@
+# Bridges GitHub "issue opened" to the Torrentarr Issue Viability Cursor Automation.
+# Cursor has no issue-opened trigger; this workflow adds the cursor-viability label
+# (Issue label changed) and optionally POSTs the automation webhook.
+
+name: Issue viability
+
+on:
+  issues:
+    types:
+    - opened
+
+permissions:
+  issues: write
+
+concurrency:
+  group: issue-viability-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  label-and-notify:
+    if: github.event.issue.pull_request == null
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Add cursor-viability label
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        if gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name' | grep -Fxq 'cursor-viability'; then
+          echo "Issue already has cursor-viability; skipping label."
+        else
+          gh label create cursor-viability \
+            --repo "$REPO" \
+            --description "Signals the Cursor Issue Viability automation" \
+            --color 1D76DB \
+            --force
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label cursor-viability
+          echo "Added cursor-viability to #$ISSUE_NUMBER."
+        fi
+
+    - name: Notify Cursor automation webhook
+      env:
+        WEBHOOK_URL: ${{ secrets.CURSOR_AUTOMATION_WEBHOOK_URL }}
+        WEBHOOK_KEY: ${{ secrets.CURSOR_AUTOMATION_WEBHOOK_KEY }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        ISSUE_TITLE: ${{ github.event.issue.title }}
+        ISSUE_BODY: ${{ github.event.issue.body }}
+        ISSUE_URL: ${{ github.event.issue.html_url }}
+        ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+      run: |
+        set -euo pipefail
+        if [[ -z "${WEBHOOK_URL}" || -z "${WEBHOOK_KEY}" ]]; then
+          echo "Webhook secrets not set; label bridge only."
+          exit 0
+        fi
+        AUTH="${WEBHOOK_KEY}"
+        if [[ "${AUTH}" != Bearer[[:space:]]* ]]; then
+          AUTH="Bearer ${AUTH}"
+        fi
+        payload="$(jq -n \
+          --arg event "issue_opened" \
+          --arg number "$ISSUE_NUMBER" \
+          --arg title "$ISSUE_TITLE" \
+          --arg body "$ISSUE_BODY" \
+          --arg html_url "$ISSUE_URL" \
+          --arg labels "$ISSUE_LABELS" \
+          '{event:$event,number:$number,title:$title,body:$body,html_url:$html_url,labels:($labels|split(",")|map(select(length>0)))}')"
+        curl --fail --silent --show-error --request POST \
+          --url "$WEBHOOK_URL" \
+          --header "Authorization: ${AUTH}" \
+          --header "Content-Type: application/json" \
+          --data "$payload"
+        echo "Posted issue #$ISSUE_NUMBER to Cursor automation webhook."

--- a/scripts/print-issue-viability-automation-setup.sh
+++ b/scripts/print-issue-viability-automation-setup.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Prints Cursor Automation setup instructions and validates repo files exist.
+# Usage: ./scripts/print-issue-viability-automation-setup.sh
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+AUTO_DIR="$ROOT/.cursor/automations/torrentarr-issue-viability"
+
+echo "=== Torrentarr Issue Viability — Cursor Automation setup ==="
+echo ""
+echo "Researches issues on open/comment; implements viable bugs; opens a non-draft PR;"
+echo "repairs CI until green; then requests human review."
+echo ""
+echo "Cursor Automations are created in the dashboard (no public create API yet)."
+echo "Open: https://cursor.com/automations/new"
+echo ""
+
+for f in automation.yaml prompt.md; do
+  if [[ -f "$AUTO_DIR/$f" ]]; then
+    echo "✓ $AUTO_DIR/$f"
+  else
+    echo "✗ missing: $AUTO_DIR/$f" >&2
+    exit 1
+  fi
+done
+
+if [[ -f "$ROOT/.github/workflows/issue-viability.yml" ]]; then
+  echo "✓ $ROOT/.github/workflows/issue-viability.yml"
+else
+  echo "✗ missing: $ROOT/.github/workflows/issue-viability.yml" >&2
+  exit 1
+fi
+
+echo ""
+echo "--- Dashboard settings ---"
+echo "Name:        Torrentarr Issue Viability"
+echo "Repository:  Feramance/Torrentarr"
+echo "Triggers:    Issue comment, Issue label changed (cursor-viability),"
+echo "             Webhook, Workflow run completed"
+echo "Tools:       Pull request creation, Request reviewers, Memories"
+echo "Permissions: Private (or Team Visible)"
+echo "Initial:     Disabled — test before enabling"
+echo ""
+echo "--- Issue-comment filters (if the dashboard supports them) ---"
+echo "Ignore authors: cursor, cursor[bot], github-actions[bot], dependabot[bot]"
+echo "Ignore body:    <!-- torrentarr-issue-viability -->"
+echo ""
+echo "--- Instructions field ---"
+echo "Paste the contents of:"
+echo "  .cursor/automations/torrentarr-issue-viability/prompt.md"
+echo ""
+echo "Or from GitHub after merge:"
+echo "  https://github.com/Feramance/Torrentarr/blob/master/.cursor/automations/torrentarr-issue-viability/prompt.md"
+echo ""
+echo "--- GitHub Action bridge ---"
+echo "On issue opened, .github/workflows/issue-viability.yml adds the"
+echo "cursor-viability label (Issue label changed trigger)."
+echo "Optional webhook fallback (when the label trigger is missing in the UI):"
+echo "  CURSOR_AUTOMATION_WEBHOOK_URL"
+echo "  CURSOR_AUTOMATION_WEBHOOK_KEY"
+echo "Copy the webhook URL and Bearer token from the automation after first save."
+echo ""
+echo "--- Test ---"
+echo "1. Confirm Cursor GitHub App is connected: https://cursor.com/dashboard/integrations"
+echo "2. Save automation as DISABLED"
+echo "3. Open a test bug issue; expect cursor-viability label + research comment"
+echo "4. For a viable bug, expect a non-draft PR (Build and Test skips drafts)"
+echo "5. When CI is green, expect a reviewer request and a human-review comment"
+echo "6. Enable the automation. Keep Cloud Agent \"Automatically fix CI Failures\" on"
+echo ""
+echo "Prompt length: $(wc -c < "$AUTO_DIR/prompt.md") bytes"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a repo-managed Cursor Automation that researches GitHub issues when they are opened or commented on, implements viable bugs, opens a non-draft PR so CI can run, repairs failures until green, then requests human review.

Cursor has no **issue opened** trigger, so a GitHub Action labels new issues `cursor-viability` and optionally POSTs the automation webhook.

## What landed
- `.cursor/automations/torrentarr-issue-viability/prompt.md` — copy-paste agent instructions
- `.cursor/automations/torrentarr-issue-viability/automation.yaml` — dashboard settings (not loaded automatically)
- `.github/workflows/issue-viability.yml` — `issues: opened` bridge
- `scripts/print-issue-viability-automation-setup.sh` — setup checklist

## Testing
- [x] `./scripts/print-issue-viability-automation-setup.sh` validates the spec files
- [x] `check-yaml`, `pretty-format-yaml`, and other file-level pre-commit hooks passed
- [x] No C# / React runtime changes
- [ ] Maintainer must paste the prompt into the Cursor Automations dashboard after merge (no public create API)

Manual test notes:
After merge, save the automation disabled, open a test bug issue, confirm the `cursor-viability` label plus a research comment, then enable.

## Checklist
- [x] Discussed scope in the implementation plan
- [x] Confirmed there are no secrets or credentials committed
- [ ] Dashboard automation is created and tested by a maintainer (post-merge)

## Additional Notes
Build and Test skips draft PRs, so the agent prompt requires ready-for-review PRs. Optional repo secrets for the webhook fallback: `CURSOR_AUTOMATION_WEBHOOK_URL`, `CURSOR_AUTOMATION_WEBHOOK_KEY`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b8d8242-b352-435b-830a-c46f727b1273?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b8d8242-b352-435b-830a-c46f727b1273&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

