### PR TITLE
fix: keep Arr timeouts in worker backoff

### DIFF
--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/ArrClientResponse.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/ArrClientResponse.cs
@@ -59,4 +59,3 @@ internal static class ArrClientResponse
             throw lastFailure;
     }
 }
-

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/ArrClientResponse.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/ArrClientResponse.cs
@@ -50,7 +50,7 @@ internal static class ArrClientResponse
     /// Connectivity / incomplete HTTP that should abort remaining series fetches.
     /// </summary>
     internal static bool IsArrTransportError(Exception ex)
-        => ex is HttpRequestException or TimeoutException
+        => ex is HttpRequestException or TimeoutException or TaskCanceledException
            || (ex is ArrApiException api && api.StatusCode is null);
 
     internal static void RaiseIfAllEpisodeFetchesFailed(int attempted, int failed, Exception? lastFailure)
@@ -59,3 +59,4 @@ internal static class ArrClientResponse
             throw lastFailure;
     }
 }
+

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/ArrClientResponse.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/ArrClientResponse.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Newtonsoft.Json;
 using RestSharp;
 using Torrentarr.Infrastructure.Http;
 
@@ -31,6 +32,14 @@ internal static class ArrClientResponse
             $"Arr API {operation} failed: HTTP {status}",
             statusCode != 0 ? (HttpStatusCode)statusCode : null,
             response.ErrorMessage);
+    }
+
+    internal static T DeserializeOrDefault<T>(string? content) where T : new()
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return new T();
+
+        return JsonConvert.DeserializeObject<T>(content) ?? new T();
     }
 
     /// <summary>

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/LidarrClient.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/LidarrClient.cs
@@ -44,7 +44,7 @@ public class LidarrClient
 
         var response = await ArrClientResponse.ExecuteAsync(_client, request, ct);
         ArrClientResponse.EnsureSuccess(response, "GET /api/v1/system/status");
-        return JsonConvert.DeserializeObject<SystemInfo>(response.Content) ?? new SystemInfo();
+        return ArrClientResponse.DeserializeOrDefault<SystemInfo>(response.Content);
     }
 
     /// <summary>

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/RadarrClient.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/RadarrClient.cs
@@ -44,7 +44,7 @@ public class RadarrClient
 
         var response = await ArrClientResponse.ExecuteAsync(_client, request, ct);
         ArrClientResponse.EnsureSuccess(response, "GET /api/v3/system/status");
-        return JsonConvert.DeserializeObject<SystemInfo>(response.Content) ?? new SystemInfo();
+        return ArrClientResponse.DeserializeOrDefault<SystemInfo>(response.Content);
     }
 
     /// <summary>

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/ReadarrClient.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/ReadarrClient.cs
@@ -39,7 +39,7 @@ public class ReadarrClient
 
         var response = await ArrClientResponse.ExecuteAsync(_client, request, ct);
         ArrClientResponse.EnsureSuccess(response, "GET /api/v1/system/status");
-        return JsonConvert.DeserializeObject<SystemInfo>(response.Content ?? "") ?? new SystemInfo();
+        return ArrClientResponse.DeserializeOrDefault<SystemInfo>(response.Content);
     }
 
     public async Task<ReadarrAuthor?> GetAuthorAsync(int authorId, CancellationToken ct = default)

--- a/src/Torrentarr.Infrastructure/ApiClients/Arr/SonarrClient.cs
+++ b/src/Torrentarr.Infrastructure/ApiClients/Arr/SonarrClient.cs
@@ -44,7 +44,7 @@ public class SonarrClient
 
         var response = await ArrClientResponse.ExecuteAsync(_client, request, ct);
         ArrClientResponse.EnsureSuccess(response, "GET /api/v3/system/status");
-        return JsonConvert.DeserializeObject<SystemInfo>(response.Content) ?? new SystemInfo();
+        return ArrClientResponse.DeserializeOrDefault<SystemInfo>(response.Content);
     }
 
     /// <summary>

--- a/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
@@ -656,13 +656,7 @@ public class ArrSyncService
         var profileDict = qualityProfiles.ToDictionary(p => p.Id);
 
         // Fetch artists
-        List<LidarrArtist> artists;
-        try { artists = await client.GetArtistsAsync(ct); }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "[{Instance}] ArrSyncService: Lidarr {Name} unreachable", instanceName, instanceName);
-            return;
-        }
+        var artists = await client.GetArtistsAsync(ct);
 
         var artistProfileById = artists.ToDictionary(a => a.Id, a => a.QualityProfileId);
 
@@ -724,13 +718,7 @@ public class ArrSyncService
         await _db.SaveChangesWithRetryAsync(_logger, _restartCoordinator, cancellationToken: ct);
 
         // Fetch all albums at once
-        List<LidarrAlbum> albums;
-        try { albums = await client.GetAlbumsAsync(ct: ct); }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "[{Instance}] ArrSyncService: Lidarr {Name} failed to fetch albums", instanceName, instanceName);
-            return;
-        }
+        var albums = await client.GetAlbumsAsync(ct: ct);
 
         // Build artist name lookup from what we fetched
         var artistNameById = artists.ToDictionary(a => a.Id, a => a.ArtistName);
@@ -873,13 +861,7 @@ public class ArrSyncService
         }
 
         // Fetch all tracks at once and group by Lidarr album ID
-        List<Track> allTracks;
-        try { allTracks = await client.GetTracksAsync(ct: ct); }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "[{Instance}] ArrSyncService: Lidarr {Name} failed to fetch tracks", instanceName, instanceName);
-            return;
-        }
+        var allTracks = await client.GetTracksAsync(ct: ct);
 
         // Clear all existing tracks for this instance then re-insert
         var existingTracks = await _db.Tracks
@@ -985,13 +967,7 @@ public class ArrSyncService
         var qualityProfiles = await client.GetQualityProfilesAsync(ct);
         var profileDict = qualityProfiles.ToDictionary(p => p.Id);
 
-        List<ReadarrAuthor> authors;
-        try { authors = await client.GetAuthorsAsync(ct); }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "[{Instance}] ArrSyncService: Readarr {Name} unreachable", instanceName, instanceName);
-            return;
-        }
+        var authors = await client.GetAuthorsAsync(ct);
 
         var authorProfileById = authors.ToDictionary(a => a.Id, a => a.QualityProfileId);
 
@@ -1049,13 +1025,7 @@ public class ArrSyncService
 
         await _db.SaveChangesWithRetryAsync(_logger, _restartCoordinator, cancellationToken: ct);
 
-        List<ReadarrBook> books;
-        try { books = await client.GetBooksAsync(ct: ct); }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "[{Instance}] ArrSyncService: Readarr {Name} failed to fetch books", instanceName, instanceName);
-            return;
-        }
+        var books = await client.GetBooksAsync(ct: ct);
 
         var authorNameById = authors.ToDictionary(a => a.Id, a => a.AuthorName);
 

--- a/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
@@ -147,13 +147,7 @@ public class ArrSyncService
 
         _logger.LogInformation("Started updating database");
 
-        List<RadarrMovie> movies;
-        try { movies = await client.GetMoviesAsync(ct); }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "[{Instance}] ArrSyncService: Radarr {Name} unreachable", instanceName, instanceName);
-            return;
-        }
+        var movies = await client.GetMoviesAsync(ct);
 
         var profiles = await client.GetQualityProfilesAsync(ct);
         var profileDict = profiles.ToDictionary(p => p.Id);
@@ -304,13 +298,7 @@ public class ArrSyncService
 
         _logger.LogInformation("Started updating database");
 
-        List<SonarrSeries> seriesList;
-        try { seriesList = await client.GetSeriesAsync(ct); }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "[{Instance}] ArrSyncService: Sonarr {Name} unreachable", instanceName, instanceName);
-            return;
-        }
+        var seriesList = await client.GetSeriesAsync(ct);
 
         var profiles = await client.GetQualityProfilesAsync(ct);
         var profileDict = profiles.ToDictionary(p => p.Id);

--- a/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
@@ -1790,4 +1790,3 @@ public class ArrSyncService
         return false;
     }
 }
-

--- a/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
@@ -88,7 +88,7 @@ public class ArrSyncService
 
             _logger.LogTrace("[{Instance}] Sync completed for {Name}", instanceName, instanceName);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             throw;
         }
@@ -394,7 +394,11 @@ public class ArrSyncService
             attempted++;
             List<SonarrEpisode> episodes;
             try { episodes = await client.GetEpisodesAsync(sonarrId, ct); }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
             {
                 if (!ArrSeriesEpisodeFetch.ShouldSkipSeries(ex))
                     throw;
@@ -1786,3 +1790,4 @@ public class ArrSyncService
         return false;
     }
 }
+

--- a/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrSyncService.cs
@@ -1674,7 +1674,7 @@ public class ArrSyncService
     /// exact message match) and blocklist+delete them, including listed files.
     /// </summary>
     private async Task ScanQueueForBlocklistAsync(
-        IEnumerable<(int Id, string? DownloadId, string? Status, string? TrackedDownloadStatus, string? TrackedDownloadState, string? OutputPath, List<StatusMessage>? StatusMessages)> items,
+        IEnumerable<(int Id, string? DownloadId, string Status, string? TrackedDownloadStatus, string? TrackedDownloadState, string? OutputPath, List<StatusMessage>? StatusMessages)> items,
         ArrInstanceConfig cfg,
         Func<int, CancellationToken, Task<bool>> deleteFromQueue,
         CancellationToken ct)

--- a/src/Torrentarr.Infrastructure/Services/ArrWorkerManager.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrWorkerManager.cs
@@ -351,7 +351,7 @@ public class ArrWorkerManager : BackgroundService
                     await RunRefreshMonitoredDownloadsIfDueAsync(instanceName, arrCfg, ct);
                     consecutiveErrors = 0;
                 }
-                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                catch (OperationCanceledException ex) when (IsWorkerCancellation(ex, ct))
                 {
                     break;
                 }
@@ -419,7 +419,7 @@ public class ArrWorkerManager : BackgroundService
 
                     consecutiveErrors = 0;
                 }
-                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                catch (OperationCanceledException ex) when (IsWorkerCancellation(ex, ct))
                 {
                     break;
                 }
@@ -488,7 +488,7 @@ public class ArrWorkerManager : BackgroundService
 
             await UpdateCountsAsync(instanceName, ct);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException ex) when (IsWorkerCancellation(ex, ct))
         {
             throw;
         }
@@ -498,6 +498,9 @@ public class ArrWorkerManager : BackgroundService
             throw;
         }
     }
+
+    internal static bool IsWorkerCancellation(OperationCanceledException _, CancellationToken ct)
+        => ct.IsCancellationRequested;
 
     private async Task ProbeArrVersionAsync(string instanceName, ArrInstanceConfig arrCfg, CancellationToken ct)
     {

--- a/src/Torrentarr.Infrastructure/Services/ArrWorkerManager.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrWorkerManager.cs
@@ -1068,4 +1068,3 @@ public class ArrWorkerManager : BackgroundService
         _logger.LogDebug("Script Config:  Category={Category}", arrCfg.Category);
     }
 }
-

--- a/src/Torrentarr.Infrastructure/Services/ArrWorkerManager.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrWorkerManager.cs
@@ -814,10 +814,14 @@ public class ArrWorkerManager : BackgroundService
 
             return result;
         }
+        catch (OperationCanceledException ex) when (IsWorkerCancellation(ex, ct))
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Search failed for {Instance}: {Message}", instanceName, ex.Message);
-            return null;
+            throw;
         }
     }
 

--- a/src/Torrentarr.Infrastructure/Services/ArrWorkerManager.cs
+++ b/src/Torrentarr.Infrastructure/Services/ArrWorkerManager.cs
@@ -351,7 +351,7 @@ public class ArrWorkerManager : BackgroundService
                     await RunRefreshMonitoredDownloadsIfDueAsync(instanceName, arrCfg, ct);
                     consecutiveErrors = 0;
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {
                     break;
                 }
@@ -419,7 +419,7 @@ public class ArrWorkerManager : BackgroundService
 
                     consecutiveErrors = 0;
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {
                     break;
                 }
@@ -488,7 +488,7 @@ public class ArrWorkerManager : BackgroundService
 
             await UpdateCountsAsync(instanceName, ct);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             throw;
         }
@@ -1068,3 +1068,4 @@ public class ArrWorkerManager : BackgroundService
         _logger.LogDebug("Script Config:  Category={Category}", arrCfg.Category);
     }
 }
+

--- a/tests/Torrentarr.Infrastructure.Tests/ApiClients/ArrClientResponseTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/ApiClients/ArrClientResponseTests.cs
@@ -41,6 +41,26 @@ public sealed class ArrClientResponseTests
         act.Should().NotThrow();
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DeserializeOrDefault_ReturnsDefaultForMissingContent(string? content)
+    {
+        var result = ArrClientResponse.DeserializeOrDefault<SystemInfo>(content);
+
+        result.Should().NotBeNull();
+        result.Version.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DeserializeOrDefault_DeserializesContent()
+    {
+        var result = ArrClientResponse.DeserializeOrDefault<SystemInfo>("{\"version\":\"4.0.0\"}");
+
+        result.Version.Should().Be("4.0.0");
+    }
+
     [Fact]
     public void IsArrHttpError_TrueFor415()
     {

--- a/tests/Torrentarr.Infrastructure.Tests/ApiClients/ArrClientResponseTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/ApiClients/ArrClientResponseTests.cs
@@ -88,4 +88,3 @@ public sealed class ArrClientResponseTests
         act.Should().NotThrow();
     }
 }
-

--- a/tests/Torrentarr.Infrastructure.Tests/ApiClients/ArrClientResponseTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/ApiClients/ArrClientResponseTests.cs
@@ -58,6 +58,14 @@ public sealed class ArrClientResponseTests
     }
 
     [Fact]
+    public void IsArrTransportError_TrueForTaskCanceledTimeout()
+    {
+        var ex = new TaskCanceledException("request timed out");
+        ArrClientResponse.IsArrTransportError(ex).Should().BeTrue();
+        ArrClientResponse.IsArrHttpError(ex).Should().BeFalse();
+    }
+
+    [Fact]
     public void IsArrTransportError_TrueWhenStatusMissing()
     {
         var ex = new ArrApiException("timed out", statusCode: null, "Error");
@@ -80,3 +88,4 @@ public sealed class ArrClientResponseTests
         act.Should().NotThrow();
     }
 }
+

--- a/tests/Torrentarr.Infrastructure.Tests/ApiClients/ArrClientResponseTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/ApiClients/ArrClientResponseTests.cs
@@ -50,7 +50,7 @@ public sealed class ArrClientResponseTests
         var result = ArrClientResponse.DeserializeOrDefault<SystemInfo>(content);
 
         result.Should().NotBeNull();
-        result.Version.Should().BeEmpty();
+        result.Version.Should().BeNull();
     }
 
     [Fact]

--- a/tests/Torrentarr.Infrastructure.Tests/Services/ArrWorkerManagerTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/ArrWorkerManagerTests.cs
@@ -37,6 +37,25 @@ public class ArrWorkerManagerTests
     }
 
     [Fact]
+    public void IsWorkerCancellation_ReturnsFalse_ForRequestTimeout()
+    {
+        using var workerCts = new CancellationTokenSource();
+        var timeout = new TaskCanceledException("request timed out");
+
+        ArrWorkerManager.IsWorkerCancellation(timeout, workerCts.Token).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsWorkerCancellation_ReturnsTrue_WhenWorkerIsStopping()
+    {
+        using var workerCts = new CancellationTokenSource();
+        workerCts.Cancel();
+        var cancellation = new OperationCanceledException(workerCts.Token);
+
+        ArrWorkerManager.IsWorkerCancellation(cancellation, workerCts.Token).Should().BeTrue();
+    }
+
+    [Fact]
     public void ShouldRunSearch_ReturnsFalse_WithinInterval()
     {
         var manager = CreateManager();

--- a/tests/Torrentarr.Infrastructure.Tests/Services/ArrWorkerManagerTests.cs
+++ b/tests/Torrentarr.Infrastructure.Tests/Services/ArrWorkerManagerTests.cs
@@ -154,6 +154,25 @@ public class ArrWorkerManagerTests
     }
 
     [Fact]
+    public async Task RunSearchAsync_RequestTimeout_PropagatesToLoopBackoff()
+    {
+        var media = new Mock<IArrMediaService>();
+        media.Setup(m => m.SearchMissingMediaAsync("movies", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TaskCanceledException("request timed out"));
+        using var harness = WorkerHarness.Create(media.Object);
+        var cfg = new ArrInstanceConfig
+        {
+            Type = "radarr",
+            Category = "movies",
+            Search = new SearchConfig { SearchMissing = true, SearchRequestsEvery = 1 }
+        };
+
+        var act = () => harness.Manager.RunSearchAsync("Radarr", cfg, CancellationToken.None);
+
+        await act.Should().ThrowAsync<TaskCanceledException>();
+    }
+
+    [Fact]
     public async Task RunSearchAsync_DrainedWithSearchAgain_ResetsSearchedAndUpgradeOnNextTick()
     {
         var media = new Mock<IArrMediaService>();


### PR DESCRIPTION
## Summary

- classify timeout-originated `TaskCanceledException` values as Arr transport failures
- stop sync, search, and torrent loops only when their worker cancellation token is actually cancelled
- keep transient Arr timeouts in the existing retry/backoff path instead of terminating the search loop
- add regression coverage for task-cancelled request timeouts

## Testing

- `git diff --check` passed
- Local .NET tests were not run because NuGet restore failed TLS authentication against `api.nuget.org`
