### PR TITLE
fix: make classifier label provisioning race-safe

### DIFF
--- a/.github/scripts/classify_work_item.py
+++ b/.github/scripts/classify_work_item.py
@@ -363,7 +363,9 @@ def classify_pr(
         mapped = "bug_fix" if linked == "bug" else linked
         if mapped in PR_CATEGORIES:
             return mapped, ["trusted_n8n_issue_handoff"]
-    if author in policy["trusted_dependency_bots"] and dependency_only(paths, policy, files):
+    if author in policy["trusted_dependency_bots"] and dependency_only(
+        paths, policy, files
+    ):
         return "package_update", ["trusted_dependency_bot", "dependency_only_files"]
     lower_labels = {label.lower() for label in labels}
     if dependency_only(paths, policy, files):
@@ -433,6 +435,15 @@ def determine_flags(
     return sorted(flags)
 
 
+class GitHubAPIError(RuntimeError):
+    """GitHub REST failure with a machine-readable status and response body."""
+
+    def __init__(self, method: str, url: str, status: int, detail: str) -> None:
+        super().__init__(f"GitHub API {method} {url} failed: {status} {detail}")
+        self.status = status
+        self.detail = detail
+
+
 class GitHubAPI:
     """Small authenticated GitHub REST client with pagination."""
 
@@ -457,9 +468,7 @@ class GitHubAPI:
                 return json.loads(raw) if raw else None
         except urllib.error.HTTPError as error:
             detail = error.read().decode("utf-8", errors="replace")
-            raise RuntimeError(
-                f"GitHub API {method} {url} failed: {error.code} {detail}"
-            ) from error
+            raise GitHubAPIError(method, url, error.code, detail) from error
 
     def pages(self, path: str) -> list[Any]:
         """Read all pages from a list endpoint."""
@@ -554,7 +563,16 @@ def ensure_labels(api: GitHubAPI) -> None:
                 "PATCH", f"/labels/{urllib.parse.quote(name, safe='')}", payload
             )
         else:
-            api.request("POST", "/labels", payload)
+            try:
+                api.request("POST", "/labels", payload)
+            except GitHubAPIError as error:
+                # Concurrent runs can all observe a missing label. If another
+                # run wins creation, converge by updating the created label.
+                if error.status != 422 or '"already_exists"' not in error.detail:
+                    raise
+                api.request(
+                    "PATCH", f"/labels/{urllib.parse.quote(name, safe='')}", payload
+                )
 
 
 def update_classification_labels(

--- a/.github/scripts/tests/test_classify_work_item.py
+++ b/.github/scripts/tests/test_classify_work_item.py
@@ -65,6 +65,47 @@ class DigestTests(unittest.TestCase):
         )
 
 
+class LabelProvisioningTests(unittest.TestCase):
+    def test_concurrent_create_converges_to_patch(self) -> None:
+        class RacingAPI:
+            def __init__(self) -> None:
+                self.calls = []
+                self.raced = False
+
+            def pages(self, _path: str) -> list:
+                return []
+
+            def request(self, method: str, path: str, payload=None):
+                self.calls.append((method, path, payload))
+                if method == "POST" and not self.raced:
+                    self.raced = True
+                    raise classifier.GitHubAPIError(
+                        method,
+                        "https://api.github.test/labels",
+                        422,
+                        '{"errors":[{"code":"already_exists"}]}',
+                    )
+                return None
+
+        api = RacingAPI()
+        classifier.ensure_labels(api)
+        self.assertEqual(api.calls[0][0], "POST")
+        self.assertEqual(api.calls[1][0], "PATCH")
+
+    def test_non_conflict_create_failure_is_not_hidden(self) -> None:
+        class FailingAPI:
+            def pages(self, _path: str) -> list:
+                return []
+
+            def request(self, method: str, _path: str, payload=None):
+                raise classifier.GitHubAPIError(
+                    method, "https://api.github.test", 403, "denied"
+                )
+
+        with self.assertRaises(classifier.GitHubAPIError):
+            classifier.ensure_labels(FailingAPI())
+
+
 class IssueTests(unittest.TestCase):
     def issue(self, title: str, body: str, labels: list[str]) -> dict:
         return {
@@ -130,7 +171,9 @@ class PullRequestTests(unittest.TestCase):
 
     def test_workflow_action_version_bump_is_package_update(self) -> None:
         files = changed(".github/workflows/ci.yml")
-        files[0]["patch"] = "@@ -1 +1 @@\n- uses: actions/checkout@v4\n+ uses: actions/checkout@v5"
+        files[0][
+            "patch"
+        ] = "@@ -1 +1 @@\n- uses: actions/checkout@v4\n+ uses: actions/checkout@v5"
         self.assertEqual(
             self.classify(pull("bump checkout", "dependabot[bot]"), files),
             "package_update",
@@ -138,7 +181,9 @@ class PullRequestTests(unittest.TestCase):
 
     def test_broad_workflow_edit_is_not_package_update(self) -> None:
         files = changed(".github/workflows/ci.yml", "webui/package-lock.json")
-        files[0]["patch"] = "@@ -1 +1 @@\n- permissions: read-all\n+ permissions: write-all"
+        files[0][
+            "patch"
+        ] = "@@ -1 +1 @@\n- permissions: read-all\n+ permissions: write-all"
         self.assertNotEqual(
             self.classify(pull("bump", "dependabot[bot]"), files),
             "package_update",


### PR DESCRIPTION
Handles concurrent classifier backfills that race while creating canonical labels. A 422 already_exists response now converges through PATCH; other API failures remain fatal. Adds regression coverage for both paths.