### PR TITLE
fix: replace stale classification labels

### DIFF
--- a/.github/scripts/classify_work_item.py
+++ b/.github/scripts/classify_work_item.py
@@ -607,7 +607,10 @@ def update_classification_labels(
         if ready
         else "automation/classification:pending"
     )
-    api.request("POST", f"/issues/{number}/labels", {"labels": sorted(set(retained))})
+    # PUT is GitHub's set-labels operation. POST only adds labels and leaves
+    # stale managed state behind, which can produce both pending/ready or
+    # multiple type labels after reclassification.
+    api.request("PUT", f"/issues/{number}/labels", {"labels": sorted(set(retained))})
 
 
 def upsert_contract_comment(

--- a/.github/scripts/tests/test_classify_work_item.py
+++ b/.github/scripts/tests/test_classify_work_item.py
@@ -66,6 +66,45 @@ class DigestTests(unittest.TestCase):
 
 
 class LabelProvisioningTests(unittest.TestCase):
+    def test_classification_labels_replace_stale_managed_labels(self) -> None:
+        class RecordingAPI:
+            def __init__(self) -> None:
+                self.calls = []
+
+            def request(self, method: str, path: str, payload=None):
+                self.calls.append((method, path, payload))
+                return None
+
+        api = RecordingAPI()
+        classifier.update_classification_labels(
+            api,
+            42,
+            [
+                "bug",
+                "automation/classification:pending",
+                "automation/type:ci",
+                "automation/type:ambiguous",
+            ],
+            "docs",
+            True,
+        )
+        self.assertEqual(
+            api.calls,
+            [
+                (
+                    "PUT",
+                    "/issues/42/labels",
+                    {
+                        "labels": [
+                            "automation/classification:ready",
+                            "automation/type:docs",
+                            "bug",
+                        ]
+                    },
+                )
+            ],
+        )
+
     def test_concurrent_create_converges_to_patch(self) -> None:
         class RacingAPI:
             def __init__(self) -> None:


### PR DESCRIPTION
Uses GitHub's set-labels operation so reclassification removes stale pending and type labels. Adds a regression test for exact managed-label reconciliation. Validation: 21 classifier unit tests and git diff --check pass.