### PR TITLE
ci: require Docker and CodeQL merge checks

### DIFF
--- a/.github/automation/merge-policy.json
+++ b/.github/automation/merge-policy.json
@@ -55,6 +55,14 @@
     {
       "app_slug": "github-actions",
       "pattern": "^build \\(.*\\)$"
+    },
+    {
+      "app_slug": "github-actions",
+      "pattern": "^Build and push Docker image \\(PR\\)$"
+    },
+    {
+      "app_slug": "github-actions",
+      "pattern": "^Analyze \\(.*\\)$"
     }
   ],
   "schema_version": 1


### PR DESCRIPTION
Makes same-repository Docker builds and CodeQL analysis mandatory in the base-SHA merge policy. Fork-only publish jobs remain explicitly inapplicable. Classifier tests and JSON validation pass locally.